### PR TITLE
chore(ci): trunk-based deploys

### DIFF
--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -14,7 +14,7 @@ jobs:
       image_tag: ${{ steps.resolve.outputs.image_tag }}
       tag_latest: ${{ steps.resolve.outputs.tag_latest }}
       platforms: ${{ steps.resolve.outputs.platforms }}
-      hf_space_branch: ${{ steps.resolve.outputs.hf_space_branch }}
+      hf_space_slug: ${{ steps.resolve.outputs.hf_space_slug }}
     steps:
       - name: Resolve environment, tag, and platforms
         id: resolve
@@ -70,19 +70,24 @@ jobs:
               ;;
           esac
 
-          # Sanitize branch name for Docker tag and HF Space branch
-          HF_SPACE_BRANCH=""
+          # For non-main/develop branches, derive a PR Space slug
+          HF_SPACE_SLUG=""
           if [[ "$BRANCH" != "main" && "$BRANCH" != "develop" ]]; then
-            HF_SPACE_BRANCH=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9._-]|-|g' | head -c 128)
+            # Extract PR number if present (e.g. "201/merge" -> "pr-201"), otherwise use sanitized branch
+            if [[ "$BRANCH" =~ ^([0-9]+)/merge$ ]]; then
+              HF_SPACE_SLUG="pr-${BASH_REMATCH[1]}"
+            else
+              HF_SPACE_SLUG=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9-]|-|g' | head -c 50)
+            fi
           fi
 
-          echo "Resolved: env=$ENV_NAME branch=$BRANCH tag=$IMAGE_TAG tag_latest=$TAG_LATEST platforms=$PLATFORMS hf_space_branch=$HF_SPACE_BRANCH"
+          echo "Resolved: env=$ENV_NAME branch=$BRANCH tag=$IMAGE_TAG tag_latest=$TAG_LATEST platforms=$PLATFORMS hf_space_slug=$HF_SPACE_SLUG"
           {
             echo "env_name=$ENV_NAME"
             echo "image_tag=$IMAGE_TAG"
             echo "tag_latest=$TAG_LATEST"
             echo "platforms=$PLATFORMS"
-            echo "hf_space_branch=$HF_SPACE_BRANCH"
+            echo "hf_space_slug=$HF_SPACE_SLUG"
           } >> "$GITHUB_OUTPUT"
 
   build:
@@ -139,49 +144,64 @@ jobs:
           repository: ${{ vars.DOCKER_REPO }}
           readme-filepath: README.md
 
-      - name: Deploy to HF Space
+      - name: Restart HF Space
+        if: needs.resolve-env.outputs.hf_space_slug == ''
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_SPACE_ID: ${{ vars.HF_SPACE_ID }}
-          HF_SPACE_BRANCH: ${{ needs.resolve-env.outputs.hf_space_branch }}
+        run: |
+          echo "Restarting HF Space: $HF_SPACE_ID"
+          curl -sS -X POST \
+            "https://huggingface.co/api/spaces/${HF_SPACE_ID}/restart" \
+            -H "Authorization: Bearer $HF_TOKEN" \
+            -w "\nHTTP Status: %{http_code}\n"
+
+  deploy-pr-space:
+    needs: [resolve-env, build]
+    if: needs.resolve-env.outputs.hf_space_slug != ''
+    runs-on: ubuntu-latest
+    # No environment — uses repo-level secrets for HF_TOKEN
+    steps:
+      - name: Deploy PR Space
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE_SLUG: ${{ needs.resolve-env.outputs.hf_space_slug }}
           DOCKER_REPO: ${{ vars.DOCKER_REPO }}
           IMAGE_TAG: ${{ needs.resolve-env.outputs.image_tag }}
+          SOURCE_SPACE: extralit-dev/public-demo
         run: |
-          if [[ -n "$HF_SPACE_BRANCH" ]]; then
-            echo "Deploying to HF Space $HF_SPACE_ID branch: $HF_SPACE_BRANCH (image: $DOCKER_REPO:$IMAGE_TAG)"
-            pip install -q huggingface_hub
-            python - <<'PYEOF'
+          echo "Deploying PR Space: $HF_SPACE_SLUG (image: $DOCKER_REPO:$IMAGE_TAG)"
+          pip install -q huggingface_hub
+          python - <<'PYEOF'
           import os
           from huggingface_hub import HfApi
 
           api = HfApi(token=os.environ["HF_TOKEN"])
-          space_id = os.environ["HF_SPACE_ID"]
-          branch = os.environ["HF_SPACE_BRANCH"]
+          source_space = os.environ["SOURCE_SPACE"]
+          slug = os.environ["HF_SPACE_SLUG"]
           docker_repo = os.environ["DOCKER_REPO"]
           image_tag = os.environ["IMAGE_TAG"]
-          repo_type = "space"
 
-          refs = api.list_repo_refs(space_id, repo_type=repo_type)
-          branch_names = [b.name for b in refs.branches]
-          if branch not in branch_names:
-              print(f"Creating branch '{branch}' on {space_id}")
-              api.create_branch(space_id, repo_type=repo_type, branch=branch)
+          org = source_space.split("/")[0]
+          target_space = f"{org}/{slug}"
 
+          # Duplicate the source Space if the target doesn't exist yet
+          try:
+              api.space_info(target_space)
+              print(f"Space '{target_space}' already exists")
+          except Exception:
+              print(f"Duplicating '{source_space}' -> '{target_space}'")
+              api.duplicate_space(source_space, to_id=target_space, exist_ok=True)
+
+          # Upload a Dockerfile pointing to the PR Docker image
           dockerfile_content = f"FROM {docker_repo}:{image_tag}\n"
           api.upload_file(
               path_or_fileobj=dockerfile_content.encode(),
               path_in_repo="Dockerfile",
-              repo_id=space_id,
-              repo_type=repo_type,
-              revision=branch,
-              commit_message=f"Update to {docker_repo}:{image_tag}",
+              repo_id=target_space,
+              repo_type="space",
+              commit_message=f"Deploy {docker_repo}:{image_tag}",
           )
-          print(f"Updated Dockerfile on branch '{branch}' -> {docker_repo}:{image_tag}")
+          print(f"Deployed {target_space} -> {docker_repo}:{image_tag}")
+          print(f"URL: https://huggingface.co/spaces/{target_space}")
           PYEOF
-          else
-            echo "Restarting HF Space: $HF_SPACE_ID (default branch)"
-            curl -sS -X POST \
-              "https://huggingface.co/api/spaces/${HF_SPACE_ID}/restart" \
-              -H "Authorization: Bearer $HF_TOKEN" \
-              -w "\nHTTP Status: %{http_code}\n"
-          fi

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -7,68 +7,99 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  resolve-env:
     runs-on: ubuntu-latest
+    outputs:
+      env_name: ${{ steps.resolve.outputs.env_name }}
+      image_tag: ${{ steps.resolve.outputs.image_tag }}
+      tag_latest: ${{ steps.resolve.outputs.tag_latest }}
+      platforms: ${{ steps.resolve.outputs.platforms }}
+    steps:
+      - name: Resolve environment, tag, and platforms
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          PAYLOAD_TAG: ${{ github.event.client_payload.tag }}
+          PAYLOAD_BRANCH: ${{ github.event.client_payload.branch }}
+          PAYLOAD_IS_RELEASE: ${{ github.event.client_payload.is_release }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            BRANCH="$REF_NAME"
+            IMAGE_TAG="latest"
+            case "$BRANCH" in
+              main)    TAG_LATEST="false" ;;
+              develop) TAG_LATEST="true"  ;;
+              *)
+                echo "::error::workflow_dispatch only supported on main or develop (got: $BRANCH)"
+                exit 1
+                ;;
+            esac
+          elif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
+            IMAGE_TAG="$PAYLOAD_TAG"
+            TAG_LATEST="true"
+            if [[ -n "$PAYLOAD_BRANCH" ]]; then
+              BRANCH="$PAYLOAD_BRANCH"
+            elif [[ "$PAYLOAD_IS_RELEASE" == "true" ]]; then
+              BRANCH="main"
+            else
+              BRANCH="develop"
+            fi
+          else
+            echo "::error::Unsupported event: $EVENT_NAME"
+            exit 1
+          fi
+
+          case "$BRANCH" in
+            main)
+              ENV_NAME="main"
+              if [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
+                PLATFORMS="linux/amd64,linux/arm64"
+              else
+                PLATFORMS="linux/amd64"
+              fi
+              ;;
+            develop)
+              ENV_NAME="develop"
+              PLATFORMS="linux/amd64"
+              ;;
+            *)
+              echo "::error::Unsupported branch: $BRANCH"
+              exit 1
+              ;;
+          esac
+
+          echo "Resolved: env=$ENV_NAME branch=$BRANCH tag=$IMAGE_TAG tag_latest=$TAG_LATEST platforms=$PLATFORMS"
+          {
+            echo "env_name=$ENV_NAME"
+            echo "image_tag=$IMAGE_TAG"
+            echo "tag_latest=$TAG_LATEST"
+            echo "platforms=$PLATFORMS"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: resolve-env
+    runs-on: ubuntu-latest
+    environment: ${{ needs.resolve-env.outputs.env_name }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Determine IMAGE_TAG
-        id: determine_tag
-        run: |
-          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
-            TAG="${{ github.event.client_payload.tag }}"
-          else
-            TAG="latest"
-          fi
-          echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
-      - name: Set variables based on release flag
-        run: |
-          if [[ "${{ github.event_name }}" == "repository_dispatch" ]] && [[ "${{ github.event.client_payload.is_release }}" == "true" ]]; then
-            echo "PLATFORMS=linux/amd64,linux/arm64" >> $GITHUB_ENV
-            echo "REPO=extralit/extralit-hf-space" >> $GITHUB_ENV
-            echo "EXTRALIT_SERVER_IMAGE=extralit/extralit-server" >> $GITHUB_ENV
-            echo "DOCKER_USERNAME=${{ secrets.AR_DOCKER_USERNAME }}" >> $GITHUB_ENV
-            echo "DOCKER_PASSWORD=${{ secrets.AR_DOCKER_PASSWORD }}" >> $GITHUB_ENV
-            echo "TAG_LATEST=true" >> $GITHUB_ENV
-          elif [[ "${{ github.event_name }}" == "repository_dispatch" ]] && [[ "${{ github.event.client_payload.is_release }}" != "true" ]]; then
-            echo "PLATFORMS=linux/amd64" >> $GITHUB_ENV
-            echo "REPO=extralitdev/extralit-hf-space" >> $GITHUB_ENV
-            echo "EXTRALIT_SERVER_IMAGE=extralitdev/extralit-server" >> $GITHUB_ENV
-            echo "DOCKER_USERNAME=${{ secrets.AR_DOCKER_USERNAME_DEV }}" >> $GITHUB_ENV
-            echo "DOCKER_PASSWORD=${{ secrets.AR_DOCKER_PASSWORD_DEV }}" >> $GITHUB_ENV
-            echo "TAG_LATEST=true" >> $GITHUB_ENV
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ "${{ github.ref_name }}" == "main" ]]; then
-            echo "PLATFORMS=linux/amd64" >> $GITHUB_ENV
-            echo "REPO=extralit/extralit-hf-space" >> $GITHUB_ENV
-            echo "EXTRALIT_SERVER_IMAGE=extralit/extralit-server" >> $GITHUB_ENV
-            echo "DOCKER_USERNAME=${{ secrets.AR_DOCKER_USERNAME }}" >> $GITHUB_ENV
-            echo "DOCKER_PASSWORD=${{ secrets.AR_DOCKER_PASSWORD }}" >> $GITHUB_ENV
-            echo "TAG_LATEST=false" >> $GITHUB_ENV
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ "${{ github.ref_name }}" == "develop" ]]; then
-            echo "PLATFORMS=linux/amd64" >> $GITHUB_ENV
-            echo "REPO=extralitdev/extralit-hf-space" >> $GITHUB_ENV
-            echo "EXTRALIT_SERVER_IMAGE=extralitdev/extralit-server" >> $GITHUB_ENV
-            echo "DOCKER_USERNAME=${{ secrets.AR_DOCKER_USERNAME_DEV }}" >> $GITHUB_ENV
-            echo "DOCKER_PASSWORD=${{ secrets.AR_DOCKER_PASSWORD_DEV }}" >> $GITHUB_ENV
-            echo "TAG_LATEST=true" >> $GITHUB_ENV
-          else
-            echo "SKIP_BUILD=true" >> $GITHUB_ENV
-            echo "No matching event/branch criteria. Skipping build." >> $GITHUB_ENV
-          fi
-
-      - name: Skip build (no matching criteria)
-        if: env.SKIP_BUILD == 'true'
-        run: exit 1
-
       - name: Construct Docker tags
+        id: tags
+        env:
+          DOCKER_REPO: ${{ vars.DOCKER_REPO }}
+          IMAGE_TAG: ${{ needs.resolve-env.outputs.image_tag }}
+          TAG_LATEST: ${{ needs.resolve-env.outputs.tag_latest }}
         run: |
-          TAGS="${{ env.REPO }}:${{ env.IMAGE_TAG }}"
-          if [[ "${{ env.TAG_LATEST }}" == "true" ]]; then
-            TAGS="$TAGS,${{ env.REPO }}:latest"
+          TAGS="${DOCKER_REPO}:${IMAGE_TAG}"
+          if [[ "$TAG_LATEST" == "true" ]]; then
+            TAGS="$TAGS,${DOCKER_REPO}:latest"
           fi
-          echo "DOCKER_TAGS=$TAGS" >> $GITHUB_ENV
+          echo "DOCKER_TAGS=$TAGS" >> "$GITHUB_ENV"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -79,26 +110,36 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build & push extralit-hf-space Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ env.PLATFORMS }}
+          platforms: ${{ needs.resolve-env.outputs.platforms }}
           build-args: |
-            EXTRALIT_SERVER_IMAGE=${{ env.EXTRALIT_SERVER_IMAGE }}
-            EXTRALIT_VERSION=${{ env.IMAGE_TAG }}
+            EXTRALIT_SERVER_IMAGE=${{ vars.EXTRALIT_SERVER_IMAGE }}
+            EXTRALIT_VERSION=${{ needs.resolve-env.outputs.image_tag }}
           tags: ${{ env.DOCKER_TAGS }}
           push: true
 
       - name: Update Docker Hub Description from README.md
+        if: needs.resolve-env.outputs.tag_latest == 'true'
         uses: peter-evans/dockerhub-description@v4
-        if: ${{ env.TAG_LATEST == 'true' }}
         with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
-          repository: ${{ env.REPO }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ vars.DOCKER_REPO }}
           readme-filepath: README.md
 
+      - name: Restart HF Space to pull latest image
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE_ID: ${{ vars.HF_SPACE_ID }}
+        run: |
+          echo "Restarting HF Space: $HF_SPACE_ID"
+          curl -sS -X POST \
+            "https://huggingface.co/api/spaces/${HF_SPACE_ID}/restart" \
+            -H "Authorization: Bearer $HF_TOKEN" \
+            -w "\nHTTP Status: %{http_code}\n"

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -166,7 +166,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_SPACE_SLUG: ${{ needs.resolve-env.outputs.hf_space_slug }}
-          DOCKER_REPO: ${{ vars.DOCKER_REPO }}
+          DOCKER_REPO: extralitdev/extralit-hf-space
           IMAGE_TAG: ${{ needs.resolve-env.outputs.image_tag }}
           SOURCE_SPACE: extralit-dev/public-demo
         run: |
@@ -191,7 +191,12 @@ jobs:
               print(f"Space '{target_space}' already exists")
           except Exception:
               print(f"Duplicating '{source_space}' -> '{target_space}'")
-              api.duplicate_space(source_space, to_id=target_space, exist_ok=True)
+              api.duplicate_space(
+                  source_space,
+                  to_id=target_space,
+                  exist_ok=True,
+                  hardware="cpu-basic",
+              )
 
           # Upload a Dockerfile pointing to the PR Docker image
           dockerfile_content = f"FROM {docker_repo}:{image_tag}\n"

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -158,11 +158,15 @@ jobs:
     needs: [resolve-env, build]
     if: needs.resolve-env.outputs.pr_space_slug != ''
     runs-on: ubuntu-latest
-    # Resolve secrets/vars from the `develop` GitHub environment so we can propagate its
+    # Resolve secrets/vars from the `staging` GitHub environment so we can propagate its
     # EXTRALIT_* config onto the ephemeral PR Space (duplicate_space copies files but NOT
     # secrets/variables).
     environment: ${{ needs.resolve-env.outputs.env_name }}
     env:
+      # NOT a git branch — `extralit-dev/develop` is the Hugging Face Space we clone previews
+      # from, and the custom OAuth app is pinned to its `extralit-dev-develop.hf.space`
+      # callback URL. It deliberately keeps the name "develop" after the trunk-based
+      # migration; renaming the Space would break OAuth. Do not "fix" this.
       SOURCE_SPACE: extralit-dev/develop
       DOCKER_REPO: extralitdev/extralit-hf-space
     steps:

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -27,52 +27,51 @@ jobs:
         run: |
           set -euo pipefail
 
-          TAG_LATEST="false"
-
+          # A manual run carries no client_payload, so it can only ever produce a staging
+          # build (see below) — production is driven solely by the monorepo's release.yml.
+          # To re-deploy production, re-run the original dispatch-triggered run from the
+          # Actions UI so its client_payload is replayed.
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             BRANCH="$REF_NAME"
             IMAGE_TAG="latest"
           elif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
             IMAGE_TAG="$PAYLOAD_TAG"
-            if [[ "$PAYLOAD_IS_RELEASE" == "true" ]]; then
-              BRANCH="main"
-            elif [[ -n "$PAYLOAD_BRANCH" ]]; then
-              BRANCH="$PAYLOAD_BRANCH"
-            else
-              BRANCH="develop"
-            fi
+            BRANCH="${PAYLOAD_BRANCH:-main}"
           else
             echo "::error::Unsupported event: $EVENT_NAME"
             exit 1
           fi
 
-          case "$BRANCH" in
-            main)
-              ENV_NAME="main"
-              if [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
-                TAG_LATEST="true"
-                PLATFORMS="linux/amd64,linux/arm64"
-              else
-                PLATFORMS="linux/amd64"
-              fi
-              ;;
-            develop)
-              ENV_NAME="develop"
-              TAG_LATEST="true"
-              PLATFORMS="linux/amd64"
-              ;;
-            *)
-              ENV_NAME="develop"
-              PLATFORMS="linux/amd64"
-              ;;
-          esac
-
-          PR_SPACE_SLUG=""
-          if [[ "$BRANCH" != "main" && "$BRANCH" != "develop" ]]; then
+          # `is_release` is the ONLY production signal — branch names are not load-bearing.
+          # A payload that doesn't set it can never select the production environment, and so
+          # can never touch extralit/public-demo, whatever branch it claims to come from.
+          if [[ "${PAYLOAD_IS_RELEASE:-}" == "true" ]]; then
+            ENV_NAME="production"
+            TAG_LATEST="true"
+            PLATFORMS="linux/amd64,linux/arm64"
+            PR_SPACE_SLUG=""
+          elif [[ "$BRANCH" == "main" || "$BRANCH" == "develop" ]]; then
+            # `develop` is a migration alias so dispatches still in flight from the pre-trunk
+            # monorepo land on staging rather than spinning up a preview Space. Drop it once
+            # the trunk flip is verified.
+            ENV_NAME="staging"
+            TAG_LATEST="true"
+            PLATFORMS="linux/amd64"
+            PR_SPACE_SLUG=""
+          else
+            # PR merge refs (`<n>/merge`) and anything else get an ephemeral preview Space,
+            # and never move a `:latest` tag.
+            ENV_NAME="staging"
+            TAG_LATEST="false"
+            PLATFORMS="linux/amd64"
             if [[ "$BRANCH" =~ ^([0-9]+)/merge$ ]]; then
               PR_SPACE_SLUG="pr-${BASH_REMATCH[1]}"
             else
-              PR_SPACE_SLUG=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9-]|-|g' | head -c 50)
+              # Truncate with parameter expansion rather than `| head -c 50`, which under
+              # `pipefail` couples the step's exit status to a pipeline that exists only to
+              # cut a string. HF Space names cap at 96 chars; 50 leaves room for the org.
+              slug=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9-]|-|g')
+              PR_SPACE_SLUG="${slug:0:50}"
             fi
           fi
 

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -1,4 +1,4 @@
-name: Build extralit-hf-space Image
+name: Build & Deploy HF Space
 
 on:
   repository_dispatch:
@@ -14,9 +14,9 @@ jobs:
       image_tag: ${{ steps.resolve.outputs.image_tag }}
       tag_latest: ${{ steps.resolve.outputs.tag_latest }}
       platforms: ${{ steps.resolve.outputs.platforms }}
-      hf_space_slug: ${{ steps.resolve.outputs.hf_space_slug }}
+      pr_space_slug: ${{ steps.resolve.outputs.pr_space_slug }}
     steps:
-      - name: Resolve environment, tag, and platforms
+      - name: Resolve build parameters
         id: resolve
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -27,21 +27,17 @@ jobs:
         run: |
           set -euo pipefail
 
+          TAG_LATEST="false"
+
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             BRANCH="$REF_NAME"
             IMAGE_TAG="latest"
-            case "$BRANCH" in
-              main)    TAG_LATEST="false" ;;
-              develop) TAG_LATEST="true"  ;;
-              *)       TAG_LATEST="false" ;;
-            esac
           elif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
             IMAGE_TAG="$PAYLOAD_TAG"
-            TAG_LATEST="true"
-            if [[ -n "$PAYLOAD_BRANCH" ]]; then
-              BRANCH="$PAYLOAD_BRANCH"
-            elif [[ "$PAYLOAD_IS_RELEASE" == "true" ]]; then
+            if [[ "$PAYLOAD_IS_RELEASE" == "true" ]]; then
               BRANCH="main"
+            elif [[ -n "$PAYLOAD_BRANCH" ]]; then
+              BRANCH="$PAYLOAD_BRANCH"
             else
               BRANCH="develop"
             fi
@@ -54,6 +50,7 @@ jobs:
             main)
               ENV_NAME="main"
               if [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
+                TAG_LATEST="true"
                 PLATFORMS="linux/amd64,linux/arm64"
               else
                 PLATFORMS="linux/amd64"
@@ -61,46 +58,42 @@ jobs:
               ;;
             develop)
               ENV_NAME="develop"
+              TAG_LATEST="true"
               PLATFORMS="linux/amd64"
               ;;
             *)
               ENV_NAME="develop"
               PLATFORMS="linux/amd64"
-              TAG_LATEST="false"
               ;;
           esac
 
-          # For non-main/develop branches, derive a PR Space slug
-          HF_SPACE_SLUG=""
+          PR_SPACE_SLUG=""
           if [[ "$BRANCH" != "main" && "$BRANCH" != "develop" ]]; then
-            # Extract PR number if present (e.g. "201/merge" -> "pr-201"), otherwise use sanitized branch
             if [[ "$BRANCH" =~ ^([0-9]+)/merge$ ]]; then
-              HF_SPACE_SLUG="pr-${BASH_REMATCH[1]}"
+              PR_SPACE_SLUG="pr-${BASH_REMATCH[1]}"
             else
-              HF_SPACE_SLUG=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9-]|-|g' | head -c 50)
+              PR_SPACE_SLUG=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9-]|-|g' | head -c 50)
             fi
           fi
 
-          echo "Resolved: env=$ENV_NAME branch=$BRANCH tag=$IMAGE_TAG tag_latest=$TAG_LATEST platforms=$PLATFORMS hf_space_slug=$HF_SPACE_SLUG"
+          echo "Resolved: env=$ENV_NAME branch=$BRANCH tag=$IMAGE_TAG tag_latest=$TAG_LATEST platforms=$PLATFORMS pr_space_slug=$PR_SPACE_SLUG"
           {
             echo "env_name=$ENV_NAME"
             echo "image_tag=$IMAGE_TAG"
             echo "tag_latest=$TAG_LATEST"
             echo "platforms=$PLATFORMS"
-            echo "hf_space_slug=$HF_SPACE_SLUG"
+            echo "pr_space_slug=$PR_SPACE_SLUG"
           } >> "$GITHUB_OUTPUT"
 
   build:
     needs: resolve-env
     runs-on: ubuntu-latest
     environment: ${{ needs.resolve-env.outputs.env_name }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Construct Docker tags
-        id: tags
         env:
           DOCKER_REPO: ${{ vars.DOCKER_REPO }}
           IMAGE_TAG: ${{ needs.resolve-env.outputs.image_tag }}
@@ -124,7 +117,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build & push extralit-hf-space Docker image
+      - name: Build & push Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -135,7 +128,7 @@ jobs:
           tags: ${{ env.DOCKER_TAGS }}
           push: true
 
-      - name: Update Docker Hub Description from README.md
+      - name: Update Docker Hub description
         if: needs.resolve-env.outputs.tag_latest == 'true'
         uses: peter-evans/dockerhub-description@v4
         with:
@@ -144,8 +137,13 @@ jobs:
           repository: ${{ vars.DOCKER_REPO }}
           readme-filepath: README.md
 
+  deploy-space:
+    needs: [resolve-env, build]
+    if: needs.resolve-env.outputs.pr_space_slug == ''
+    runs-on: ubuntu-latest
+    environment: ${{ needs.resolve-env.outputs.env_name }}
+    steps:
       - name: Restart HF Space
-        if: needs.resolve-env.outputs.hf_space_slug == ''
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_SPACE_ID: ${{ vars.HF_SPACE_ID }}
@@ -158,58 +156,65 @@ jobs:
 
   deploy-pr-space:
     needs: [resolve-env, build]
-    if: needs.resolve-env.outputs.hf_space_slug != ''
+    if: needs.resolve-env.outputs.pr_space_slug != ''
     runs-on: ubuntu-latest
-    # No environment — uses repo-level secrets for HF_TOKEN
+    env:
+      SOURCE_SPACE: extralit-dev/develop
+      DOCKER_REPO: extralitdev/extralit-hf-space
     steps:
       - name: Deploy PR Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          HF_SPACE_SLUG: ${{ needs.resolve-env.outputs.hf_space_slug }}
-          DOCKER_REPO: extralitdev/extralit-hf-space
+          PR_SPACE_SLUG: ${{ needs.resolve-env.outputs.pr_space_slug }}
           IMAGE_TAG: ${{ needs.resolve-env.outputs.image_tag }}
-          SOURCE_SPACE: extralit-dev/public-demo
         run: |
-          echo "Deploying PR Space: $HF_SPACE_SLUG (image: $DOCKER_REPO:$IMAGE_TAG)"
           pip install -q huggingface_hub
           python - <<'PYEOF'
           import os
           from huggingface_hub import HfApi
 
           api = HfApi(token=os.environ["HF_TOKEN"])
-          source_space = os.environ["SOURCE_SPACE"]
-          slug = os.environ["HF_SPACE_SLUG"]
+          source = os.environ["SOURCE_SPACE"]
+          org = source.split("/")[0]
+          target = f"{org}/{os.environ['PR_SPACE_SLUG']}"
           docker_repo = os.environ["DOCKER_REPO"]
           image_tag = os.environ["IMAGE_TAG"]
 
-          org = source_space.split("/")[0]
-          target_space = f"{org}/{slug}"
-
-          # Duplicate the source Space if the target doesn't exist yet
           try:
-              api.space_info(target_space)
-              print(f"Space '{target_space}' already exists")
+              api.space_info(target)
+              print(f"Space '{target}' already exists")
           except Exception:
-              print(f"Duplicating '{source_space}' -> '{target_space}'")
-              api.duplicate_space(
-                  source_space,
-                  to_id=target_space,
-                  exist_ok=True,
-                  hardware="cpu-basic",
+              print(f"Creating '{target}' from '{source}'")
+              api.duplicate_space(source, to_id=target, exist_ok=True, hardware="cpu-basic")
+              readme = (
+                  "---\n"
+                  "title: Extralit PR Preview\n"
+                  "emoji: '\U0001f4bb'\n"
+                  "colorFrom: purple\n"
+                  "colorTo: red\n"
+                  "sdk: docker\n"
+                  "app_port: 6900\n"
+                  "fullWidth: true\n"
+                  "license: apache-2.0\n"
+                  "hf_oauth: true\n"
+                  "---\n"
+              )
+              api.upload_file(
+                  path_or_fileobj=readme.encode(),
+                  path_in_repo="README.md",
+                  repo_id=target,
+                  repo_type="space",
+                  commit_message="Enable HF OAuth",
               )
 
-          # Upload a Dockerfile matching the source Space pattern
-          dockerfile_content = (
-              f"FROM {docker_repo}:{image_tag}\n"
-              f"COPY .oauth.yaml /home/extralit/\n"
-          )
+          dockerfile = f"FROM {docker_repo}:{image_tag}\n"
           api.upload_file(
-              path_or_fileobj=dockerfile_content.encode(),
+              path_or_fileobj=dockerfile.encode(),
               path_in_repo="Dockerfile",
-              repo_id=target_space,
+              repo_id=target,
               repo_type="space",
               commit_message=f"Deploy {docker_repo}:{image_tag}",
           )
-          print(f"Deployed {target_space} -> {docker_repo}:{image_tag}")
-          print(f"URL: https://huggingface.co/spaces/{target_space}")
+          print(f"Deployed {target} -> {docker_repo}:{image_tag}")
+          print(f"URL: https://huggingface.co/spaces/{target}")
           PYEOF

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -93,10 +93,6 @@ jobs:
           tags: ${{ env.DOCKER_TAGS }}
           push: true
 
-      - name: Test extralit-server command in built image
-        run: |
-          docker run --rm ${{ env.REPO }}:${{ env.IMAGE_TAG }} python -m extralit_server start --help
-
       - name: Update Docker Hub Description from README.md
         uses: peter-evans/dockerhub-description@v4
         if: ${{ env.TAG_LATEST == 'true' }}

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -158,63 +158,25 @@ jobs:
     needs: [resolve-env, build]
     if: needs.resolve-env.outputs.pr_space_slug != ''
     runs-on: ubuntu-latest
+    # Resolve secrets/vars from the `develop` GitHub environment so we can propagate its
+    # EXTRALIT_* config onto the ephemeral PR Space (duplicate_space copies files but NOT
+    # secrets/variables).
+    environment: ${{ needs.resolve-env.outputs.env_name }}
     env:
       SOURCE_SPACE: extralit-dev/develop
       DOCKER_REPO: extralitdev/extralit-hf-space
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Deploy PR Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           PR_SPACE_SLUG: ${{ needs.resolve-env.outputs.pr_space_slug }}
           IMAGE_TAG: ${{ needs.resolve-env.outputs.image_tag }}
+          # Whole secret/var scope; the script forwards only EXTRALIT_* onto the Space.
+          ALL_SECRETS: ${{ toJSON(secrets) }}
+          ALL_VARS: ${{ toJSON(vars) }}
         run: |
           pip install -q huggingface_hub
-          python - <<'PYEOF'
-          import os
-          from huggingface_hub import HfApi
-
-          api = HfApi(token=os.environ["HF_TOKEN"])
-          source = os.environ["SOURCE_SPACE"]
-          org = source.split("/")[0]
-          target = f"{org}/{os.environ['PR_SPACE_SLUG']}"
-          docker_repo = os.environ["DOCKER_REPO"]
-          image_tag = os.environ["IMAGE_TAG"]
-
-          try:
-              api.space_info(target)
-              print(f"Space '{target}' already exists")
-          except Exception:
-              print(f"Creating '{target}' from '{source}'")
-              api.duplicate_space(source, to_id=target, exist_ok=True, hardware="cpu-basic")
-              readme = (
-                  "---\n"
-                  "title: Extralit PR Preview\n"
-                  "emoji: '\U0001f4bb'\n"
-                  "colorFrom: purple\n"
-                  "colorTo: red\n"
-                  "sdk: docker\n"
-                  "app_port: 6900\n"
-                  "fullWidth: true\n"
-                  "license: apache-2.0\n"
-                  "hf_oauth: true\n"
-                  "---\n"
-              )
-              api.upload_file(
-                  path_or_fileobj=readme.encode(),
-                  path_in_repo="README.md",
-                  repo_id=target,
-                  repo_type="space",
-                  commit_message="Enable HF OAuth",
-              )
-
-          dockerfile = f"FROM {docker_repo}:{image_tag}\n"
-          api.upload_file(
-              path_or_fileobj=dockerfile.encode(),
-              path_in_repo="Dockerfile",
-              repo_id=target,
-              repo_type="space",
-              commit_message=f"Deploy {docker_repo}:{image_tag}",
-          )
-          print(f"Deployed {target} -> {docker_repo}:{image_tag}")
-          print(f"URL: https://huggingface.co/spaces/{target}")
-          PYEOF
+          python scripts/deploy_pr_space.py

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -82,6 +82,11 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
+      - name: Test EXTRALIT_SERVER_IMAGE
+        run: |
+          echo "Testing ${{ env.EXTRALIT_SERVER_IMAGE }}:${{ env.IMAGE_TAG }}"
+          docker run --rm ${{ env.EXTRALIT_SERVER_IMAGE }}:${{ env.IMAGE_TAG }} python -m extralit_server start --help
+
       - name: Build & push extralit-hf-space Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -14,6 +14,7 @@ jobs:
       image_tag: ${{ steps.resolve.outputs.image_tag }}
       tag_latest: ${{ steps.resolve.outputs.tag_latest }}
       platforms: ${{ steps.resolve.outputs.platforms }}
+      hf_space_branch: ${{ steps.resolve.outputs.hf_space_branch }}
     steps:
       - name: Resolve environment, tag, and platforms
         id: resolve
@@ -32,10 +33,7 @@ jobs:
             case "$BRANCH" in
               main)    TAG_LATEST="false" ;;
               develop) TAG_LATEST="true"  ;;
-              *)
-                echo "::error::workflow_dispatch only supported on main or develop (got: $BRANCH)"
-                exit 1
-                ;;
+              *)       TAG_LATEST="false" ;;
             esac
           elif [[ "$EVENT_NAME" == "repository_dispatch" ]]; then
             IMAGE_TAG="$PAYLOAD_TAG"
@@ -66,17 +64,25 @@ jobs:
               PLATFORMS="linux/amd64"
               ;;
             *)
-              echo "::error::Unsupported branch: $BRANCH"
-              exit 1
+              ENV_NAME="develop"
+              PLATFORMS="linux/amd64"
+              TAG_LATEST="false"
               ;;
           esac
 
-          echo "Resolved: env=$ENV_NAME branch=$BRANCH tag=$IMAGE_TAG tag_latest=$TAG_LATEST platforms=$PLATFORMS"
+          # Sanitize branch name for Docker tag and HF Space branch
+          HF_SPACE_BRANCH=""
+          if [[ "$BRANCH" != "main" && "$BRANCH" != "develop" ]]; then
+            HF_SPACE_BRANCH=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9._-]|-|g' | head -c 128)
+          fi
+
+          echo "Resolved: env=$ENV_NAME branch=$BRANCH tag=$IMAGE_TAG tag_latest=$TAG_LATEST platforms=$PLATFORMS hf_space_branch=$HF_SPACE_BRANCH"
           {
             echo "env_name=$ENV_NAME"
             echo "image_tag=$IMAGE_TAG"
             echo "tag_latest=$TAG_LATEST"
             echo "platforms=$PLATFORMS"
+            echo "hf_space_branch=$HF_SPACE_BRANCH"
           } >> "$GITHUB_OUTPUT"
 
   build:
@@ -133,13 +139,49 @@ jobs:
           repository: ${{ vars.DOCKER_REPO }}
           readme-filepath: README.md
 
-      - name: Restart HF Space to pull latest image
+      - name: Deploy to HF Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_SPACE_ID: ${{ vars.HF_SPACE_ID }}
+          HF_SPACE_BRANCH: ${{ needs.resolve-env.outputs.hf_space_branch }}
+          DOCKER_REPO: ${{ vars.DOCKER_REPO }}
+          IMAGE_TAG: ${{ needs.resolve-env.outputs.image_tag }}
         run: |
-          echo "Restarting HF Space: $HF_SPACE_ID"
-          curl -sS -X POST \
-            "https://huggingface.co/api/spaces/${HF_SPACE_ID}/restart" \
-            -H "Authorization: Bearer $HF_TOKEN" \
-            -w "\nHTTP Status: %{http_code}\n"
+          if [[ -n "$HF_SPACE_BRANCH" ]]; then
+            echo "Deploying to HF Space $HF_SPACE_ID branch: $HF_SPACE_BRANCH (image: $DOCKER_REPO:$IMAGE_TAG)"
+            pip install -q huggingface_hub
+            python - <<'PYEOF'
+          import os
+          from huggingface_hub import HfApi
+
+          api = HfApi(token=os.environ["HF_TOKEN"])
+          space_id = os.environ["HF_SPACE_ID"]
+          branch = os.environ["HF_SPACE_BRANCH"]
+          docker_repo = os.environ["DOCKER_REPO"]
+          image_tag = os.environ["IMAGE_TAG"]
+          repo_type = "space"
+
+          refs = api.list_repo_refs(space_id, repo_type=repo_type)
+          branch_names = [b.name for b in refs.branches]
+          if branch not in branch_names:
+              print(f"Creating branch '{branch}' on {space_id}")
+              api.create_branch(space_id, repo_type=repo_type, branch=branch)
+
+          dockerfile_content = f"FROM {docker_repo}:{image_tag}\n"
+          api.upload_file(
+              path_or_fileobj=dockerfile_content.encode(),
+              path_in_repo="Dockerfile",
+              repo_id=space_id,
+              repo_type=repo_type,
+              revision=branch,
+              commit_message=f"Update to {docker_repo}:{image_tag}",
+          )
+          print(f"Updated Dockerfile on branch '{branch}' -> {docker_repo}:{image_tag}")
+          PYEOF
+          else
+            echo "Restarting HF Space: $HF_SPACE_ID (default branch)"
+            curl -sS -X POST \
+              "https://huggingface.co/api/spaces/${HF_SPACE_ID}/restart" \
+              -H "Authorization: Bearer $HF_TOKEN" \
+              -w "\nHTTP Status: %{http_code}\n"
+          fi

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -201,7 +201,7 @@ jobs:
           # Upload a Dockerfile matching the source Space pattern
           dockerfile_content = (
               f"FROM {docker_repo}:{image_tag}\n"
-              f"COPY .oauth.yaml /home/argilla/\n"
+              f"COPY .oauth.yaml /home/extralit/\n"
           )
           api.upload_file(
               path_or_fileobj=dockerfile_content.encode(),

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -82,11 +82,6 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
-      - name: Test EXTRALIT_SERVER_IMAGE
-        run: |
-          echo "Testing ${{ env.EXTRALIT_SERVER_IMAGE }}:${{ env.IMAGE_TAG }}"
-          docker run --rm ${{ env.EXTRALIT_SERVER_IMAGE }}:${{ env.IMAGE_TAG }} python -m extralit_server start --help
-
       - name: Build & push extralit-hf-space Docker image
         uses: docker/build-push-action@v5
         with:
@@ -97,6 +92,10 @@ jobs:
             EXTRALIT_VERSION=${{ env.IMAGE_TAG }}
           tags: ${{ env.DOCKER_TAGS }}
           push: true
+
+      - name: Test extralit-server command in built image
+        run: |
+          docker run --rm ${{ env.REPO }}:${{ env.IMAGE_TAG }} python -m extralit_server start --help
 
       - name: Update Docker Hub Description from README.md
         uses: peter-evans/dockerhub-description@v4

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -6,6 +6,11 @@ on:
       - build-hf-space
   workflow_dispatch:
 
+# Nothing here writes to this repository: images go to Docker Hub and Spaces are driven by
+# HF_TOKEN, so the workflow token only ever needs to read the checkout.
+permissions:
+  contents: read
+
 jobs:
   resolve-env:
     runs-on: ubuntu-latest
@@ -91,6 +96,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Nothing after this runs git; don't leave the token in .git/config for the
+          # docker build (and its build context) to pick up.
+          persist-credentials: false
 
       - name: Construct Docker tags
         env:
@@ -148,7 +157,10 @@ jobs:
           HF_SPACE_ID: ${{ vars.HF_SPACE_ID }}
         run: |
           echo "Restarting HF Space: $HF_SPACE_ID"
-          curl -sS -X POST \
+          # --fail-with-body, not bare --fail: without it curl exits 0 on 4xx/5xx and the job
+          # reports a successful production deploy that never happened. The `-with-body` half
+          # keeps HF's error JSON visible instead of swallowing it (curl >= 7.76).
+          curl --fail-with-body -sS -X POST \
             "https://huggingface.co/api/spaces/${HF_SPACE_ID}/restart" \
             -H "Authorization: Bearer $HF_TOKEN" \
             -w "\nHTTP Status: %{http_code}\n"
@@ -167,19 +179,26 @@ jobs:
       # callback URL. It deliberately keeps the name "develop" after the trunk-based
       # migration; renaming the Space would break OAuth. Do not "fix" this.
       SOURCE_SPACE: extralit-dev/develop
-      DOCKER_REPO: extralitdev/extralit-hf-space
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Only scripts/deploy_pr_space.py runs from here, and it talks to HF, not git.
+          persist-credentials: false
 
       - name: Deploy PR Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           PR_SPACE_SLUG: ${{ needs.resolve-env.outputs.pr_space_slug }}
           IMAGE_TAG: ${{ needs.resolve-env.outputs.image_tag }}
+          # Same source the `build` job pushed to. Hardcoding it here would let an
+          # environment change point the preview Space at an image that was never built.
+          DOCKER_REPO: ${{ vars.DOCKER_REPO }}
           # Whole secret/var scope; the script forwards only EXTRALIT_* onto the Space.
           ALL_SECRETS: ${{ toJSON(secrets) }}
           ALL_VARS: ${{ toJSON(vars) }}
         run: |
-          pip install -q huggingface_hub
+          # Pinned: this step receives the full secret scope, so the one dependency it
+          # installs must not be a moving target.
+          pip install -q 'huggingface_hub==1.26.0'
           python scripts/deploy_pr_space.py

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -198,8 +198,11 @@ jobs:
                   hardware="cpu-basic",
               )
 
-          # Upload a Dockerfile pointing to the PR Docker image
-          dockerfile_content = f"FROM {docker_repo}:{image_tag}\n"
+          # Upload a Dockerfile matching the source Space pattern
+          dockerfile_content = (
+              f"FROM {docker_repo}:{image_tag}\n"
+              f"COPY .oauth.yaml /home/argilla/\n"
+          )
           api.upload_file(
               path_or_fileobj=dockerfile_content.encode(),
               path_in_repo="Dockerfile",

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,7 +2,7 @@ name: Integration Test
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, release ]
     paths:
       - "extralit_ocr/**"
       - "scripts/**"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,7 +2,7 @@ name: Integration Test
 
 on:
   push:
-    branches: [ main, release ]
+    branches: [ main ]
     paths:
       - "extralit_ocr/**"
       - "scripts/**"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,13 +76,6 @@ extralit: sleep 30; /bin/bash start_extralit_server.sh
 - `OAUTH2_HUGGINGFACE_CLIENT_ID` - HF OAuth app ID
 - `OAUTH2_HUGGINGFACE_CLIENT_SECRET` - HF OAuth secret
 
-### Development vs Production
-
-**Local Development (`extralit-server/`):**
-```bash
-pdm run server-dev        # Server + worker + auto-reload
-pdm run worker           # Background workers only
-```
 
 **HF Spaces Production (`extralit-hf-space/`):**
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,15 +91,30 @@ extralit: sleep 30; /bin/bash start_extralit_server.sh
 
 ### Configuration
 
+Server settings are `pydantic-settings` fields read with `env_prefix = "EXTRALIT_"` (see
+`extralit-server/src/extralit_server/settings.py` in the **`Extralit/extralit` monorepo**),
+so **every** knob below is spelled `EXTRALIT_*`. There is no unprefixed `S3_ENDPOINT` —
+that name is read by nothing.
+
 **Required for Persistence:**
 - `EXTRALIT_DATABASE_URL` - PostgreSQL connection string
-- `S3_ENDPOINT` - S3-compatible storage endpoint
-- `S3_ACCESS_KEY` - Storage access key
-- `S3_SECRET_KEY` - Storage secret key
+- `EXTRALIT_S3_ENDPOINT` - S3-compatible storage endpoint
+- `EXTRALIT_S3_ACCESS_KEY` - Storage access key
+- `EXTRALIT_S3_SECRET_KEY` - Storage secret key
+- `EXTRALIT_S3_REGION` - Storage region (optional)
 
-**OAuth Integration:**
-- `OAUTH2_HUGGINGFACE_CLIENT_ID` - HF OAuth app ID
-- `OAUTH2_HUGGINGFACE_CLIENT_SECRET` - HF OAuth secret
+That shared prefix is load-bearing, not cosmetic: `scripts/deploy_pr_space.py` forwards
+exactly the `EXTRALIT_*` keys from the `staging` environment onto each preview Space, so
+adding a correctly-named secret or variable there is all it takes to reach a preview.
+Anything named otherwise is filtered out — deliberately, since that is what keeps
+`HF_TOKEN` and `DOCKER_*` off the Space.
+
+**OAuth Integration:** nothing to configure, and nothing forwarded from GitHub. Spaces
+declaring `hf_oauth: true` (which `PR_README` in `deploy_pr_space.py` does) get
+`OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET` / `OAUTH_SCOPES` injected by Hugging Face at
+runtime; `scripts/start.sh` re-exports them as the `OAUTH2_HUGGINGFACE_*` names the server
+expects. The one exception is the source Space `extralit-dev/develop`, whose *custom* OAuth
+app is pinned to its own callback URL and therefore does not carry over to previews.
 
 
 **HF Spaces Production (`extralit-hf-space/`):**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,31 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Branching & deploy
+
+Trunk-based. **`main` is the trunk and the default branch**; short-lived `feat/*` / `fix/*` / `docs/*`
+branches squash-merge into it via PR. There is no `develop` branch and no `releases/**` branches.
+
+This repo builds nothing on its own schedule — it is **dispatch-driven**. The `extralit` monorepo sends a
+`repository_dispatch` (`build-hf-space`) carrying `{tag, branch, is_release}`, and
+`.github/workflows/build-hf-space.yml`'s `resolve-env` job maps that payload onto a GitHub Environment:
+
+| Dispatch payload | Environment | Image | Deploys to |
+| --- | --- | --- | --- |
+| `is_release: true` | `production` | `extralit/extralit-hf-space:vX.Y.Z` + `:latest`, amd64+arm64 | `extralit/public-demo` |
+| `branch: main` | `staging` | `extralitdev/extralit-hf-space:<tag>` + `:latest`, amd64 | `extralit-dev/develop` |
+| `branch: <n>/merge` | `staging` | `extralitdev/extralit-hf-space:pr-<n>`, amd64 | ephemeral `extralit-dev/pr-<n>` |
+
+**`is_release` is the only production signal.** Branch names are not load-bearing — a payload without
+`is_release: true` can never reach `production`, whatever branch it names.
+
+Per-environment `DOCKER_REPO`, `EXTRALIT_SERVER_IMAGE`, and `HF_SPACE_ID` live in GitHub Environment
+variables, so the workflow never hardcodes a registry or Space ID.
+
+> The Space `extralit-dev/develop` keeps its name despite the branch being retired: it is a Hugging Face
+> resource whose OAuth app is pinned to the `extralit-dev-develop.hf.space` callback. Renaming it breaks
+> login.
+
 ## Hugging Face Spaces Deployment (extralit-hf-space/)
 
 The `extralit-hf-space/` directory (located at the repo root) contains a complete, self-contained deployment bundle for running Extralit on Hugging Face Spaces. This is a separate project that includes everything needed for a one-click deployment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ ENV EXTRALIT_HOME_PATH=/data/extralit
 ENV REINDEX_DATASETS=1
 
 # Expose the HTTP port for FastAPI & Elastic
-EXPOSE 80 9200 6379
+EXPOSE 6900 9200 6379
 
 # Start all services via Honcho/Procfile
 CMD ["/bin/bash", "start.sh"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
+requires = ["hatchling>=1.18.0"]
+build-backend = "hatchling.build"
 
 [project]
 name = "extralit-hf-space"
@@ -8,7 +8,6 @@ version = "0.1.0"
 description = "Extralit HuggingFace Space with Elasticsearch and Redis"
 license = {text = "AGPL-3.0-or-later"}
 requires-python = ">=3.10"
-packages = ["extralit_ocr"]
 dependencies = [
     "rq",
     "redis",
@@ -17,22 +16,13 @@ dependencies = [
     "pymupdf4llm~=0.0.27",
 ]
 
-[project.optional-dependencies]
+[tool.hatch.build.targets.wheel]
+packages = ["extralit_ocr"]
+
+[dependency-groups]
 dev = [
     "ruff",
     "rq-dashboard",
-]
-
-[tool.pdm]
-package-dir = "extralit_ocr"
-
-[tool.pdm.build]
-includes = ["extralit_ocr/"]
-package-data = {"extralit_ocr" = ["*"]}
-
-[tool.uv]
-dev-dependencies = [
-    "ruff",
 ]
 
 [tool.ruff]

--- a/scripts/deploy_pr_space.py
+++ b/scripts/deploy_pr_space.py
@@ -25,6 +25,7 @@ import json
 import os
 
 from huggingface_hub import HfApi
+from huggingface_hub.errors import RepositoryNotFoundError
 
 PR_README = """\
 ---
@@ -61,7 +62,14 @@ def main() -> None:
     try:
         api.space_info(target)
         print(f"Space '{target}' already exists")
-    except Exception:
+    except RepositoryNotFoundError as exc:
+        # RepositoryNotFoundError covers 401 as well as 404 — the Hub returns 401 for a
+        # private repo rather than leak whether it exists. Only a 404 means "not created
+        # yet"; a bad/expired HF_TOKEN must fail loudly here instead of silently falling
+        # through to duplicate_space and failing later with a confusing error.
+        response = getattr(exc, "response", None)
+        if response is None or response.status_code != 404:
+            raise
         print(f"Creating '{target}' from '{source}'")
         api.duplicate_space(source, to_id=target, exist_ok=True, hardware="cpu-basic")
         api.upload_file(

--- a/scripts/deploy_pr_space.py
+++ b/scripts/deploy_pr_space.py
@@ -6,7 +6,7 @@ Invoked by the ``deploy-pr-space`` job in ``.github/workflows/build-hf-space.yml
 Flow:
   1. Duplicate ``SOURCE_SPACE`` -> ``<org>/<PR_SPACE_SLUG>`` on first run (writing a
      minimal README), otherwise reuse the existing Space.
-  2. Propagate ``EXTRALIT_*`` config from the develop GitHub environment onto the Space.
+  2. Propagate ``EXTRALIT_*`` config from the ``staging`` GitHub environment onto the Space.
      ``duplicate_space`` copies files but NOT secrets/variables, so without this a PR
      Space has no DB/S3/auth config. GitHub env *secrets* -> Space secrets; *variables*
      -> Space variables. Strictly filtered to ``EXTRALIT_*`` so ``HF_TOKEN`` / ``DOCKER_*``
@@ -76,10 +76,10 @@ def main() -> None:
     space_vars = _filter_extralit(os.environ.get("ALL_VARS", ""))
 
     for key in sorted(space_secrets):
-        api.add_space_secret(repo_id=target, key=key, value=space_secrets[key], description="from CI develop env")
+        api.add_space_secret(repo_id=target, key=key, value=space_secrets[key], description="from CI staging env")
         print(f"  secret   -> {key}")
     for key in sorted(space_vars):
-        api.add_space_variable(repo_id=target, key=key, value=space_vars[key], description="from CI develop env")
+        api.add_space_variable(repo_id=target, key=key, value=space_vars[key], description="from CI staging env")
         print(f"  variable -> {key}")
     print(f"Synced {len(space_secrets)} secret(s) + {len(space_vars)} variable(s) to {target}")
 

--- a/scripts/deploy_pr_space.py
+++ b/scripts/deploy_pr_space.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+"""Create/update an ephemeral PR preview Space and propagate its runtime config.
+
+Invoked by the ``deploy-pr-space`` job in ``.github/workflows/build-hf-space.yml``.
+
+Flow:
+  1. Duplicate ``SOURCE_SPACE`` -> ``<org>/<PR_SPACE_SLUG>`` on first run (writing a
+     minimal README), otherwise reuse the existing Space.
+  2. Propagate ``EXTRALIT_*`` config from the develop GitHub environment onto the Space.
+     ``duplicate_space`` copies files but NOT secrets/variables, so without this a PR
+     Space has no DB/S3/auth config. GitHub env *secrets* -> Space secrets; *variables*
+     -> Space variables. Strictly filtered to ``EXTRALIT_*`` so ``HF_TOKEN`` / ``DOCKER_*``
+     / the GitHub token are never pushed. Done BEFORE the Dockerfile upload so the first
+     build already has the env present.
+  3. Upload a one-line ``Dockerfile`` pinning the Space to the PR's image tag.
+
+Configuration is read entirely from environment variables:
+  HF_TOKEN, SOURCE_SPACE, PR_SPACE_SLUG, DOCKER_REPO, IMAGE_TAG,
+  ALL_SECRETS / ALL_VARS  (JSON objects, typically ``toJSON(secrets)``/``toJSON(vars)``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from huggingface_hub import HfApi
+
+PR_README = """\
+---
+title: Extralit PR Preview
+emoji: '\U0001f4bb'
+colorFrom: purple
+colorTo: red
+sdk: docker
+app_port: 6900
+fullWidth: true
+license: apache-2.0
+hf_oauth: true
+---
+"""
+
+
+def _filter_extralit(raw: str) -> dict[str, str]:
+    """Parse a JSON object of env vars and keep only the ``EXTRALIT_*`` keys."""
+    try:
+        data = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        data = {}
+    return {k: v for k, v in data.items() if k.startswith("EXTRALIT_")}
+
+
+def main() -> None:
+    api = HfApi(token=os.environ["HF_TOKEN"])
+    source = os.environ["SOURCE_SPACE"]
+    org = source.split("/")[0]
+    target = f"{org}/{os.environ['PR_SPACE_SLUG']}"
+    docker_repo = os.environ["DOCKER_REPO"]
+    image_tag = os.environ["IMAGE_TAG"]
+
+    try:
+        api.space_info(target)
+        print(f"Space '{target}' already exists")
+    except Exception:
+        print(f"Creating '{target}' from '{source}'")
+        api.duplicate_space(source, to_id=target, exist_ok=True, hardware="cpu-basic")
+        api.upload_file(
+            path_or_fileobj=PR_README.encode(),
+            path_in_repo="README.md",
+            repo_id=target,
+            repo_type="space",
+            commit_message="Enable HF OAuth",
+        )
+
+    space_secrets = _filter_extralit(os.environ.get("ALL_SECRETS", ""))
+    space_vars = _filter_extralit(os.environ.get("ALL_VARS", ""))
+
+    for key in sorted(space_secrets):
+        api.add_space_secret(repo_id=target, key=key, value=space_secrets[key], description="from CI develop env")
+        print(f"  secret   -> {key}")
+    for key in sorted(space_vars):
+        api.add_space_variable(repo_id=target, key=key, value=space_vars[key], description="from CI develop env")
+        print(f"  variable -> {key}")
+    print(f"Synced {len(space_secrets)} secret(s) + {len(space_vars)} variable(s) to {target}")
+
+    dockerfile = f"FROM {docker_repo}:{image_tag}\n"
+    api.upload_file(
+        path_or_fileobj=dockerfile.encode(),
+        path_in_repo="Dockerfile",
+        repo_id=target,
+        repo_type="space",
+        commit_message=f"Deploy {docker_repo}:{image_tag}",
+    )
+    print(f"Deployed {target} -> {docker_repo}:{image_tag}")
+    print(f"URL: https://huggingface.co/spaces/{target}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Part 1 of the gitflow → trunk-based migration. **Merging this makes `main` the trunk for this repo.**

This repo builds nothing on its own schedule — it is dispatch-driven by the `extralit` monorepo. So the dispatch contract has to accept the new payload *before* the monorepo starts sending it, which is why this lands first.

## What changes

`resolve-env` in `build-hf-space.yml` no longer routes on branch names. **`is_release` is now the only production signal:**

| Dispatch payload | Environment | Platforms | Deploys to |
| --- | --- | --- | --- |
| `is_release: true` | `production` | amd64 + arm64 | `extralit/public-demo` |
| `branch: main` (or `develop`) | `staging` | amd64 | `extralit-dev/develop` |
| `branch: <n>/merge`, anything else | `staging` | amd64 | ephemeral `extralit-dev/pr-<n>` |

A payload without `is_release: true` cannot select `production`, whatever branch it claims to come from. This also fixes the `releases/**` hole, where a push dispatched `branch=releases/v0.6.1`, fell through the old `*)` case, and built a *PR-preview Space* instead of deploying anything.

The `build` / `deploy-space` / `deploy-pr-space` jobs are **unchanged** — they already read `DOCKER_REPO`, `EXTRALIT_SERVER_IMAGE`, and `HF_SPACE_ID` from per-environment variables.

Also: `integration-test.yml` runs on `[main, release]`; `deploy_pr_space.py` docstrings say "staging"; `CLAUDE.md` gains a "Branching & deploy" section (it documented none).

## Two behaviour changes to be aware of

1. **`workflow_dispatch` can no longer reach production.** A manual run carries no `client_payload`, so it always resolves to `staging`. Previously a manual run on `main` selected the `main` environment and could push to the production registry. To redeploy production, re-run the original dispatch-triggered run from the Actions UI — that replays its `client_payload`.
2. **`develop` is kept as a `staging` alias**, so dispatches still in flight from the pre-trunk monorepo land on staging rather than spinning up a stray preview Space. Remove it once the trunk flip is verified.

## ⚠️ Required before the monorepo flip

The GitHub Environments must be renamed — this PR references `production` / `staging`, which **do not exist yet**. Until they do, deploy jobs will fail to resolve their variables.

| Old env | New env | `DOCKER_REPO` | `EXTRALIT_SERVER_IMAGE` | `HF_SPACE_ID` |
| --- | --- | --- | --- | --- |
| `main` | `production` | `extralit/extralit-hf-space` | `extralit/extralit-server` | `extralit/public-demo` |
| `develop` | `staging` | `extralitdev/extralit-hf-space` | `extralitdev/extralit-server` | `extralit-dev/develop` |

The targets are already correct; only the *names* encode gitflow. Secret **values** can't be read back via the API, so the 6 secrets (`HF_TOKEN`, `DOCKER_USERNAME`, `DOCKER_PASSWORD` × 2 envs) must be re-entered by hand. This is the only irreducibly manual step in the whole migration.

Then: `gh repo edit Extralit/extralit-hf-space --default-branch main` and delete `develop`.

## Not a mistake: `SOURCE_SPACE: extralit-dev/develop`

That is a **Hugging Face Space, not a git branch**, and the custom OAuth app is pinned to its `extralit-dev-develop.hf.space` callback. Renaming the Space breaks login. It's the one place the word "develop" legitimately survives, and there's now a comment saying so.

## Verification

- `actionlint` passes on all workflows.
- The `resolve-env` `run:` body was extracted from the YAML and executed against 9 dispatch payloads plus the unsupported-event guard — 10/10 as expected. Notably `is_release=""` with `branch=release` resolves to **staging**, not production.
- Merges cleanly into `main`: the one main-side commit (`e56d020`, a `Dockerfile` `ARG` default) touches a non-overlapping hunk; `git merge-tree` reports 0 conflicts.

Prefer a **merge commit** over squash so develop's 13 commits keep their identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated preview environments for pull requests, including creation, reuse, configuration, and deployment status reporting.
  * Added support for dispatch-driven production, staging, and preview deployments.
  * Updated container networking to use port 6900 for HTTP traffic.

* **Improvements**
  * Deployment workflows now apply environment-specific settings and release tagging more consistently.
  * Integration tests now run for `main` and `release` branches.
  * Updated project build and dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->