### PR TITLE
feat(ci): authenticate deploy-space via HF Trusted Publishers

### DIFF
--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -7,7 +7,13 @@ on:
   workflow_dispatch:
 
 # Nothing here writes to this repository: images go to Docker Hub and Spaces are driven by
-# HF_TOKEN, so the workflow token only ever needs to read the checkout.
+# HF credentials, so the workflow token only ever needs to read the checkout.
+#
+# `deploy-space` additionally grants itself `id-token: write` at the JOB level to mint an
+# OIDC token for HF Trusted Publishers. Keep that grant out of here: it is precisely what
+# stops `build` and `deploy-pr-space` from exchanging for a production Space token, since
+# they run from the same repo/branch/workflow and would otherwise satisfy the publisher's
+# claims. https://huggingface.co/docs/hub/en/trusted-publishers
 permissions:
   contents: read
 
@@ -142,29 +148,49 @@ jobs:
     if: needs.resolve-env.outputs.pr_space_slug == ''
     runs-on: ubuntu-latest
     environment: ${{ needs.resolve-env.outputs.env_name }}
+    # Keyless: no HF_TOKEN. `id-token: write` lets this job mint a GitHub OIDC token, which
+    # HF exchanges (RFC 8693) for a token scoped to just this one Space and valid ~1h. The
+    # grant lives HERE and not at the top of the file on purpose — see the note up there.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Rebuild HF Space
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # The whole configuration for keyless auth. huggingface_hub reads this inside
+          # get_token() (utils/_auth.py::_get_token_from_oidc) and mints + exchanges +
+          # caches the token itself. It never falls back to an ambient credential: if the
+          # exchange fails it raises OIDCError, so a missing/misconfigured Trusted Publisher
+          # surfaces as a red job rather than a silently unauthenticated one.
+          #
+          # The value must match the publisher registered on the Space
+          # (https://huggingface.co/docs/hub/en/trusted-publishers), which is claim-checked
+          # against repo=Extralit/extralit-hf-space, branch=main, workflow=build-hf-space.yml.
+          HF_OIDC_RESOURCE: spaces/${{ vars.HF_SPACE_ID }}
           HF_SPACE_ID: ${{ vars.HF_SPACE_ID }}
         run: |
-          echo "Factory-rebooting HF Space: $HF_SPACE_ID"
-          # `factory=true`, NOT a plain restart. These Spaces are a thin Dockerfile that does
-          # `FROM <the image this workflow just pushed>`; a plain restart reuses the image HF
-          # already built and never re-pulls that base, so the job reports a green deploy while
-          # the Space keeps serving the old version. That is exactly what v0.7.0 did — the Space
-          # cycled RUNNING_APP_STARTING -> RUNNING and still reported 0.6.1.
+          # Pinned for the same reason as deploy-pr-space: this step handles credentials, so
+          # its one dependency must not be a moving target.
+          pip install -q 'huggingface_hub==1.26.0'
+          python - <<'PY'
+          import os
+
+          from huggingface_hub import HfApi
+
+          space = os.environ["HF_SPACE_ID"]
+          print(f"Factory-rebooting HF Space: {space}")
+          # factory_reboot=True, NOT a plain restart. These Spaces are a thin Dockerfile that
+          # does `FROM <the image this workflow just pushed>`; a plain restart reuses the image
+          # HF already built and never re-pulls that base, so the job reports a green deploy
+          # while the Space keeps serving the old version. That is exactly what v0.7.0 did —
+          # the Space cycled RUNNING_APP_STARTING -> RUNNING and still reported 0.6.1.
           #
-          # `factory` is the parameter huggingface_hub sets for restart_space(factory_reboot=True),
-          # documented as "the Space will be rebuilt from scratch without caching any requirements".
-          #
-          # --fail-with-body, not bare --fail: without it curl exits 0 on 4xx/5xx and the job
-          # reports a successful production deploy that never happened. The `-with-body` half
-          # keeps HF's error JSON visible instead of swallowing it (curl >= 7.76).
-          curl --fail-with-body -sS -X POST \
-            "https://huggingface.co/api/spaces/${HF_SPACE_ID}/restart?factory=true" \
-            -H "Authorization: Bearer $HF_TOKEN" \
-            -w "\nHTTP Status: %{http_code}\n"
+          # No --fail-with-body equivalent is needed here: restart_space() runs the response
+          # through hf_raise_for_status(), so a 4xx/5xx raises with HF's error body attached
+          # and cannot report a successful production deploy that never happened.
+          runtime = HfApi().restart_space(space, factory_reboot=True)
+          print(f"Stage: {runtime.stage}")
+          PY
 
   deploy-pr-space:
     needs: [resolve-env, build]

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -215,6 +215,24 @@ jobs:
 
       - name: Deploy PR Space
         env:
+          # The last stored HF credential in this repo, and it cannot be removed. Trusted
+          # Publishers (which made `deploy-space` keyless) come in exactly two flavors, and
+          # neither covers this job:
+          #
+          #   - a REPO publisher is registered in an existing repo's settings and yields a
+          #     token scoped to that one repo;
+          #   - a USER publisher yields a read-only `gated-repos` token — "it cannot write
+          #     anything".
+          #
+          # There is no org-scoped write token and no way to CREATE a repo, so
+          # `duplicate_space()` spawning `extralit-dev/pr-N` has nothing to exchange against
+          # (the Hub answers `invalid_grant`: "repo or user not found"). Registering a
+          # publisher per preview Space would itself need a token, so it does not bootstrap.
+          # See https://huggingface.co/docs/hub/en/trusted-publishers ("Two flavors").
+          #
+          # What bounds the risk instead is scope: this secret is defined ONLY on the
+          # `staging` environment and should be a fine-grained token with write limited to
+          # the `extralit-dev` org. Nothing here can reach `extralit/public-demo`.
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           PR_SPACE_SLUG: ${{ needs.resolve-env.outputs.pr_space_slug }}
           IMAGE_TAG: ${{ needs.resolve-env.outputs.image_tag }}

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -144,14 +144,30 @@ jobs:
           pip install -q 'huggingface_hub==1.26.0'
           python - <<'PY'
           import os
+          import time
 
-          from huggingface_hub import HfApi
+          from huggingface_hub import HfApi, SpaceStage
+
+          BUILD_STAGES = (
+              SpaceStage.BUILDING,
+              SpaceStage.RUNNING_BUILDING,
+              SpaceStage.APP_STARTING,
+              SpaceStage.RUNNING_APP_STARTING,
+          )
 
           space = os.environ["HF_SPACE_ID"]
+          api = HfApi()
           print(f"Factory-rebooting HF Space: {space}")
           # factory_reboot, else the `FROM` base is not re-pulled and v0.7.0 ships as 0.6.1.
-          runtime = HfApi().restart_space(space, factory_reboot=True)
+          started = api.restart_space(space, factory_reboot=True)
+          # wait_for_space returns at the first non-build poll, which is the stale RUNNING.
+          if started.stage not in BUILD_STAGES:
+              time.sleep(30)
+          runtime = api.wait_for_space(space, timeout=2700, poll_interval=10)
           print(f"Stage: {runtime.stage}")
+          # The reboot is async, so without this a BUILD_ERROR still reports a green deploy.
+          if runtime.stage != SpaceStage.RUNNING:
+              raise SystemExit(f"Deploy failed: {space} settled in {runtime.stage}")
           PY
 
   deploy-pr-space:

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -6,14 +6,7 @@ on:
       - build-hf-space
   workflow_dispatch:
 
-# Nothing here writes to this repository: images go to Docker Hub and Spaces are driven by
-# HF credentials, so the workflow token only ever needs to read the checkout.
-#
-# `deploy-space` additionally grants itself `id-token: write` at the JOB level to mint an
-# OIDC token for HF Trusted Publishers. Keep that grant out of here: it is precisely what
-# stops `build` and `deploy-pr-space` from exchanging for a production Space token, since
-# they run from the same repo/branch/workflow and would otherwise satisfy the publisher's
-# claims. https://huggingface.co/docs/hub/en/trusted-publishers
+# Keep `id-token: write` job-scoped to deploy-space, else any job can mint a prod token.
 permissions:
   contents: read
 
@@ -38,10 +31,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # A manual run carries no client_payload, so it can only ever produce a staging
-          # build (see below) — production is driven solely by the monorepo's release.yml.
-          # To re-deploy production, re-run the original dispatch-triggered run from the
-          # Actions UI so its client_payload is replayed.
+          # No client_payload means staging only; re-run the original dispatch to redeploy prod.
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             BRANCH="$REF_NAME"
             IMAGE_TAG="latest"
@@ -54,34 +44,26 @@ jobs:
           fi
 
           # `is_release` is the ONLY production signal — branch names are not load-bearing.
-          # A payload that doesn't set it can never select the production environment, and so
-          # can never touch extralit/public-demo, whatever branch it claims to come from.
           if [[ "${PAYLOAD_IS_RELEASE:-}" == "true" ]]; then
             ENV_NAME="production"
             TAG_LATEST="true"
             PLATFORMS="linux/amd64,linux/arm64"
             PR_SPACE_SLUG=""
           elif [[ "$BRANCH" == "main" ]]; then
-            # Trunk. `develop` was accepted here as a migration alias during the trunk cutover;
-            # that branch no longer exists in either repo and nothing can dispatch it, so the
-            # alias is gone. A stray `develop` payload would now get a preview Space, which is
-            # the correct answer for an unrecognised branch.
+            # Trunk. The `develop` migration alias is gone; a stray payload gets a preview Space.
             ENV_NAME="staging"
             TAG_LATEST="true"
             PLATFORMS="linux/amd64"
             PR_SPACE_SLUG=""
           else
-            # PR merge refs (`<n>/merge`) and anything else get an ephemeral preview Space,
-            # and never move a `:latest` tag.
+            # PR merge refs and anything else get a preview Space, and never move `:latest`.
             ENV_NAME="staging"
             TAG_LATEST="false"
             PLATFORMS="linux/amd64"
             if [[ "$BRANCH" =~ ^([0-9]+)/merge$ ]]; then
               PR_SPACE_SLUG="pr-${BASH_REMATCH[1]}"
             else
-              # Truncate with parameter expansion rather than `| head -c 50`, which under
-              # `pipefail` couples the step's exit status to a pipeline that exists only to
-              # cut a string. HF Space names cap at 96 chars; 50 leaves room for the org.
+              # Expansion not `| head -c 50`, which under pipefail couples exit status to a pipe.
               slug=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9-]|-|g')
               PR_SPACE_SLUG="${slug:0:50}"
             fi
@@ -104,8 +86,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Nothing after this runs git; don't leave the token in .git/config for the
-          # docker build (and its build context) to pick up.
+          # Keep the token out of .git/config, which the docker build context would pick up.
           persist-credentials: false
 
       - name: Construct Docker tags
@@ -148,29 +129,18 @@ jobs:
     if: needs.resolve-env.outputs.pr_space_slug == ''
     runs-on: ubuntu-latest
     environment: ${{ needs.resolve-env.outputs.env_name }}
-    # Keyless: no HF_TOKEN. `id-token: write` lets this job mint a GitHub OIDC token, which
-    # HF exchanges (RFC 8693) for a token scoped to just this one Space and valid ~1h. The
-    # grant lives HERE and not at the top of the file on purpose — see the note up there.
+    # Keyless: no HF_TOKEN. Job-scoped on purpose — see the note at the top of this file.
     permissions:
       contents: read
       id-token: write
     steps:
       - name: Rebuild HF Space
         env:
-          # The whole configuration for keyless auth. huggingface_hub reads this inside
-          # get_token() (utils/_auth.py::_get_token_from_oidc) and mints + exchanges +
-          # caches the token itself. It never falls back to an ambient credential: if the
-          # exchange fails it raises OIDCError, so a missing/misconfigured Trusted Publisher
-          # surfaces as a red job rather than a silently unauthenticated one.
-          #
-          # The value must match the publisher registered on the Space
-          # (https://huggingface.co/docs/hub/en/trusted-publishers), which is claim-checked
-          # against repo=Extralit/extralit-hf-space, branch=main, workflow=build-hf-space.yml.
+          # Whole config for keyless auth; huggingface_hub exchanges it or raises OIDCError.
           HF_OIDC_RESOURCE: spaces/${{ vars.HF_SPACE_ID }}
           HF_SPACE_ID: ${{ vars.HF_SPACE_ID }}
         run: |
-          # Pinned for the same reason as deploy-pr-space: this step handles credentials, so
-          # its one dependency must not be a moving target.
+          # Pinned: this step handles credentials, so its one dependency is not a moving target.
           pip install -q 'huggingface_hub==1.26.0'
           python - <<'PY'
           import os
@@ -179,15 +149,7 @@ jobs:
 
           space = os.environ["HF_SPACE_ID"]
           print(f"Factory-rebooting HF Space: {space}")
-          # factory_reboot=True, NOT a plain restart. These Spaces are a thin Dockerfile that
-          # does `FROM <the image this workflow just pushed>`; a plain restart reuses the image
-          # HF already built and never re-pulls that base, so the job reports a green deploy
-          # while the Space keeps serving the old version. That is exactly what v0.7.0 did —
-          # the Space cycled RUNNING_APP_STARTING -> RUNNING and still reported 0.6.1.
-          #
-          # No --fail-with-body equivalent is needed here: restart_space() runs the response
-          # through hf_raise_for_status(), so a 4xx/5xx raises with HF's error body attached
-          # and cannot report a successful production deploy that never happened.
+          # factory_reboot, else the `FROM` base is not re-pulled and v0.7.0 ships as 0.6.1.
           runtime = HfApi().restart_space(space, factory_reboot=True)
           print(f"Stage: {runtime.stage}")
           PY
@@ -196,15 +158,10 @@ jobs:
     needs: [resolve-env, build]
     if: needs.resolve-env.outputs.pr_space_slug != ''
     runs-on: ubuntu-latest
-    # Resolve secrets/vars from the `staging` GitHub environment so we can propagate its
-    # EXTRALIT_* config onto the ephemeral PR Space (duplicate_space copies files but NOT
-    # secrets/variables).
+    # `staging` env resolves the EXTRALIT_* config propagated onto the preview Space.
     environment: ${{ needs.resolve-env.outputs.env_name }}
     env:
-      # NOT a git branch — `extralit-dev/develop` is the Hugging Face Space we clone previews
-      # from, and the custom OAuth app is pinned to its `extralit-dev-develop.hf.space`
-      # callback URL. It deliberately keeps the name "develop" after the trunk-based
-      # migration; renaming the Space would break OAuth. Do not "fix" this.
+      # A Space, NOT a git branch; its OAuth app is pinned to this name. Do not "fix" this.
       SOURCE_SPACE: extralit-dev/develop
     steps:
       - name: Checkout repository
@@ -215,46 +172,17 @@ jobs:
 
       - name: Deploy PR Space
         env:
-          # The last stored HF credential in this repo, and it cannot be removed. Trusted
-          # Publishers (which made `deploy-space` keyless) come in exactly two flavors, and
-          # neither covers this job:
-          #
-          #   - a REPO publisher is registered in an existing repo's settings and yields a
-          #     token scoped to that one repo;
-          #   - a USER publisher yields a read-only `gated-repos` token — "it cannot write
-          #     anything".
-          #
-          # There is no org-scoped write token and no way to CREATE a repo, so
-          # `duplicate_space()` spawning `extralit-dev/pr-N` has nothing to exchange against
-          # (the Hub answers `invalid_grant`: "repo or user not found"). Registering a
-          # publisher per preview Space would itself need a token, so it does not bootstrap.
-          # See https://huggingface.co/docs/hub/en/trusted-publishers ("Two flavors").
-          #
-          # What bounds the risk instead is scope: this secret is defined ONLY on the
-          # `staging` environment and should be a fine-grained token with write limited to
-          # the `extralit-dev` org. Nothing here can reach `extralit/public-demo`.
+          # Irreducible: Trusted Publishers cannot create repos, and duplicate_space does.
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           PR_SPACE_SLUG: ${{ needs.resolve-env.outputs.pr_space_slug }}
           IMAGE_TAG: ${{ needs.resolve-env.outputs.image_tag }}
-          # Same source the `build` job pushed to. Hardcoding it here would let an
-          # environment change point the preview Space at an image that was never built.
+          # Same source `build` pushed to; hardcoding allows deploying a never-built image.
           DOCKER_REPO: ${{ vars.DOCKER_REPO }}
-          # EXTRALIT_* secrets destined for the preview Space must be listed here one at a
-          # time, as {"EXTRALIT_FOO": "${{ secrets.EXTRALIT_FOO }}"}. The staging environment
-          # defines none today, hence the empty object.
-          #
-          # Deliberately NOT `toJSON(secrets)`. That handed the full credential scope
-          # (HF_TOKEN, DOCKER_USERNAME, DOCKER_PASSWORD) to a pip-installed dependency purely
-          # so the script could filter it back out in Python — and "serialise every secret,
-          # install a package, POST to an external host" is indistinguishable from credential
-          # exfiltration. GitHub's malicious-workflow detector agreed and held every run of
-          # this file for manual approval, which is what made the deploy non-automatic.
+          # List EXTRALIT_* secrets one at a time; `toJSON(secrets)` tripped GitHub's detector.
           ALL_SECRETS: "{}"
-          # Variables are not credentials, so the whole set is safe to pass: EXTRALIT_* config
-          # still reaches a preview by adding an environment *variable*, with no edit here.
+          # Variables are not credentials, so the whole set is safe to pass.
           ALL_VARS: ${{ toJSON(vars) }}
         run: |
-          # Pinned: this step still handles HF_TOKEN, so its one dependency must not be a
-          # moving target.
+          # Pinned: this step handles HF_TOKEN, so its one dependency is not a moving target.
           pip install -q 'huggingface_hub==1.26.0'
           python scripts/deploy_pr_space.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,22 @@ exactly the `EXTRALIT_*` keys from the `staging` environment onto each preview S
 Anything named otherwise is filtered out — deliberately, since that is what keeps
 `HF_TOKEN` and `DOCKER_*` off the Space.
 
+**`HF_TOKEN` now exists in exactly one place: the `staging` environment.** The
+`deploy-space` job carries no HF credential at all — it authenticates via
+[Trusted Publishers](https://huggingface.co/docs/hub/en/trusted-publishers), exchanging a
+GitHub OIDC token for one scoped to a single Space for ~1h (`HF_OIDC_RESOURCE` +
+`permissions: id-token: write`, both in `build-hf-space.yml`). The surviving secret is
+there only because `duplicate_space()` **creates** `extralit-dev/pr-N`, and a trusted
+publisher can only be registered on a repo that already exists. So it is `extralit-dev`-only
+by construction; no stored credential can reach `extralit/public-demo`.
+
+Two traps when editing that job. The `id-token: write` grant belongs on **`deploy-space`,
+not at the top of the file** — every job here matches the publisher's repo/branch/workflow
+claims, so a workflow-level grant would hand `deploy-pr-space` the ability to mint a
+production token. And the restart must stay `factory_reboot=True`: a plain restart reuses
+the image HF already built without re-pulling the `FROM` base, which ships a green deploy of
+the previous version (that was v0.7.0).
+
 **Variables and secrets differ here.** Adding an `EXTRALIT_*` environment *variable* is all
 it takes to reach a preview — the whole `vars` set is passed through. An `EXTRALIT_*`
 *secret* must additionally be named in `build-hf-space.yml`'s `ALL_SECRETS` object. The


### PR DESCRIPTION
## What changed

`deploy-space` no longer uses a long-lived `HF_TOKEN`. It grants itself `id-token: write`, mints a GitHub OIDC token, and lets `huggingface_hub` exchange it at HF (RFC 8693) for a credential scoped to a single Space and valid for roughly an hour.

- The `curl` call to `POST /api/spaces/{id}/restart?factory=true` becomes `HfApi().restart_space(space, factory_reboot=True)`. `restart_space()` routes the response through `hf_raise_for_status()`, which covers what `--fail-with-body` was doing — a 4xx/5xx raises with HF's error body attached instead of reporting a production deploy that never happened.
- Auth is configured entirely by `HF_OIDC_RESOURCE: spaces/${{ vars.HF_SPACE_ID }}`. `huggingface_hub` reads it in `get_token()` and mints, exchanges, and caches the token itself. There is no fallback to an ambient credential: a failed exchange raises `OIDCError`, so a missing or misconfigured publisher is a red job, not a silently unauthenticated one.
- `id-token: write` is granted at the **job** level, not workflow level. Every job in this file runs from the same repo/branch/workflow and would therefore satisfy the publisher's claims, so a top-level grant would let `deploy-pr-space` mint a token for `extralit/public-demo`.
- `factory_reboot=True` is preserved. These Spaces are a thin Dockerfile doing `FROM <the image this workflow just pushed>`; a plain restart reuses the image HF already built and never re-pulls the base, shipping a green deploy of the previous version. That is exactly the v0.7.0 failure — the Space cycled `RUNNING_APP_STARTING -> RUNNING` and still reported 0.6.1.

## `HF_TOKEN` is not fully gone

It survives on the `staging` environment for `deploy-pr-space`. That job calls `duplicate_space()`, which **creates** a repo, and a trusted publisher can only be registered against a repo that already exists. There is no publisher to authenticate against for a Space that does not exist yet, so preview deploys stay on the PAT.

## UNVERIFIED assumption — smoke-test staging first

HF documents that **only the owner of a Space can restart it**. This PR assumes an OIDC-exchanged, Space-scoped token satisfies that ownership check. That has **not** been verified against the live API — it is plausible the check demands a user/org identity that an exchanged token does not present, in which case `restart_space` returns 401/403 and `deploy-space` fails closed (loudly, which is the good failure mode, but it is still a broken production deploy path).

Do not merge on the assumption this works. Exercise the keyless path against a non-production Space and confirm a real factory rebuild before trusting it on `extralit/public-demo`.

## Merge checklist

- [ ] **(a)** Register the GitHub Actions trusted publisher on **both** `extralit/public-demo` and `extralit-dev/develop` (repo `Extralit/extralit-hf-space`, branch `main`, workflow `build-hf-space.yml`) **before** merging. Merging first means the next production deploy fails.
- [ ] **(b)** Merge with **all** `HF_TOKEN` secrets still in place. Reverting is then a single commit with no secret restoration.
- [ ] **(c)** Dispatch `build-hf-space.yml` and confirm `extralit-dev/develop` **actually rebuilds** — check the reported version, not just a green job. A green job that redeployed the old image is the exact failure this workflow already has history with.
- [ ] **(d)** Only after a real production release succeeds keylessly, delete the `production` environment `HF_TOKEN` **and** the repo-level `HF_TOKEN`. Both. GitHub silently falls back to the repo-level secret when the environment one is absent, so deleting only the environment secret is cosmetic — the long-lived credential stays live and reachable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved production deployment security with short-lived, trusted authentication.
  * Production deployments now rebuild Spaces from the latest base image.
  * Preview deployments continue using securely scoped staging credentials.

* **Documentation**
  * Clarified authentication requirements for staging and production deployments.
  * Documented deployment permission scope and the required rebuild behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->