### PR TITLE
fix(ci): deploy the Space by committing a digest pin, not restart_space

### DIFF
--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -82,6 +82,9 @@ jobs:
     needs: resolve-env
     runs-on: ubuntu-latest
     environment: ${{ needs.resolve-env.outputs.env_name }}
+    outputs:
+      # Multi-platform builds yield the manifest-list digest, which is what `FROM` wants.
+      image_digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -114,6 +117,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build & push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -134,38 +138,53 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Rebuild HF Space
+      - name: Pin HF Space to the image just built
         env:
           # Whole config for keyless auth; huggingface_hub exchanges it or raises OIDCError.
           HF_OIDC_RESOURCE: spaces/${{ vars.HF_SPACE_ID }}
           HF_SPACE_ID: ${{ vars.HF_SPACE_ID }}
+          DOCKER_REPO: ${{ vars.DOCKER_REPO }}
+          IMAGE_DIGEST: ${{ needs.build.outputs.image_digest }}
         run: |
           # Pinned: this step handles credentials, so its one dependency is not a moving target.
           pip install -q 'huggingface_hub==1.26.0'
           python - <<'PY'
           import os
+          import re
           import time
 
           from huggingface_hub import HfApi, SpaceStage
 
-          BUILD_STAGES = (
-              SpaceStage.BUILDING,
-              SpaceStage.RUNNING_BUILDING,
-              SpaceStage.APP_STARTING,
-              SpaceStage.RUNNING_APP_STARTING,
-          )
-
           space = os.environ["HF_SPACE_ID"]
+          pin = f"{os.environ['DOCKER_REPO']}@{os.environ['IMAGE_DIGEST']}"
           api = HfApi()
-          print(f"Factory-rebooting HF Space: {space}")
-          # factory_reboot, else the `FROM` base is not re-pulled and v0.7.0 ships as 0.6.1.
-          started = api.restart_space(space, factory_reboot=True)
-          # wait_for_space returns at the first non-build poll, which is the stale RUNNING.
-          if started.stage not in BUILD_STAGES:
+
+          # Commit-to-rebuild, not restart_space: the restart API rejects OIDC tokens with a 401.
+          with open(api.hf_hub_download(space, "Dockerfile", repo_type="space")) as fh:
+              before = fh.read()
+          after, found = re.subn(r"^FROM\s+\S+", f"FROM {pin}", before, count=1, flags=re.M)
+          if not found:
+              raise SystemExit(f"No FROM line in the {space} Dockerfile")
+
+          if after == before:
+              # Already serving this digest, so a no-op commit would trigger no rebuild to wait for.
+              print(f"{space} already pinned to {pin}")
+              runtime = api.get_space_runtime(space)
+          else:
+              print(f"Pinning {space} to {pin}")
+              api.upload_file(
+                  path_or_fileobj=after.encode(),
+                  path_in_repo="Dockerfile",
+                  repo_id=space,
+                  repo_type="space",
+                  commit_message=f"Deploy {pin}",
+              )
+              # wait_for_space returns at the first non-build poll, which is the stale RUNNING.
               time.sleep(30)
-          runtime = api.wait_for_space(space, timeout=2700, poll_interval=10)
+              runtime = api.wait_for_space(space, timeout=2700, poll_interval=10)
+
           print(f"Stage: {runtime.stage}")
-          # The reboot is async, so without this a BUILD_ERROR still reports a green deploy.
+          # The rebuild is async, so without this a BUILD_ERROR still reports a green deploy.
           if runtime.stage != SpaceStage.RUNNING:
               raise SystemExit(f"Deploy failed: {space} settled in {runtime.stage}")
           PY

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -138,6 +138,14 @@ jobs:
       contents: read
       id-token: write
     steps:
+      # Pinned by SHA, not tag: this job holds the production OIDC token, so neither of its
+      # dependencies may be a moving target.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+          sparse-checkout: scripts
+
       - name: Pin HF Space to the image just built
         env:
           # Whole config for keyless auth; huggingface_hub exchanges it or raises OIDCError.
@@ -148,46 +156,7 @@ jobs:
         run: |
           # Pinned: this step handles credentials, so its one dependency is not a moving target.
           pip install -q 'huggingface_hub==1.26.0'
-          python - <<'PY'
-          import os
-          import re
-          import time
-
-          from huggingface_hub import HfApi, SpaceStage
-
-          space = os.environ["HF_SPACE_ID"]
-          pin = f"{os.environ['DOCKER_REPO']}@{os.environ['IMAGE_DIGEST']}"
-          api = HfApi()
-
-          # Commit-to-rebuild, not restart_space: the restart API rejects OIDC tokens with a 401.
-          with open(api.hf_hub_download(space, "Dockerfile", repo_type="space")) as fh:
-              before = fh.read()
-          after, found = re.subn(r"^FROM\s+\S+", f"FROM {pin}", before, count=1, flags=re.M)
-          if not found:
-              raise SystemExit(f"No FROM line in the {space} Dockerfile")
-
-          if after == before:
-              # Already serving this digest, so a no-op commit would trigger no rebuild to wait for.
-              print(f"{space} already pinned to {pin}")
-              runtime = api.get_space_runtime(space)
-          else:
-              print(f"Pinning {space} to {pin}")
-              api.upload_file(
-                  path_or_fileobj=after.encode(),
-                  path_in_repo="Dockerfile",
-                  repo_id=space,
-                  repo_type="space",
-                  commit_message=f"Deploy {pin}",
-              )
-              # wait_for_space returns at the first non-build poll, which is the stale RUNNING.
-              time.sleep(30)
-              runtime = api.wait_for_space(space, timeout=2700, poll_interval=10)
-
-          print(f"Stage: {runtime.stage}")
-          # The rebuild is async, so without this a BUILD_ERROR still reports a green deploy.
-          if runtime.stage != SpaceStage.RUNNING:
-              raise SystemExit(f"Deploy failed: {space} settled in {runtime.stage}")
-          PY
+          python scripts/deploy_space.py
 
   deploy-pr-space:
     needs: [resolve-env, build]

--- a/.github/workflows/build-hf-space.yml
+++ b/.github/workflows/build-hf-space.yml
@@ -179,9 +179,10 @@ jobs:
           # Irreducible: Trusted Publishers cannot create repos, and duplicate_space does.
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           PR_SPACE_SLUG: ${{ needs.resolve-env.outputs.pr_space_slug }}
-          IMAGE_TAG: ${{ needs.resolve-env.outputs.image_tag }}
           # Same source `build` pushed to; hardcoding allows deploying a never-built image.
           DOCKER_REPO: ${{ vars.DOCKER_REPO }}
+          # `:pr-N` is re-pushed every build, so a tag here lets HF reuse a stale base.
+          IMAGE_DIGEST: ${{ needs.build.outputs.image_digest }}
           # List EXTRALIT_* secrets one at a time; `toJSON(secrets)` tripped GitHub's detector.
           ALL_SECRETS: "{}"
           # Variables are not credentials, so the whole set is safe to pass.

--- a/.github/workflows/space-config.yml
+++ b/.github/workflows/space-config.yml
@@ -1,0 +1,54 @@
+name: Space config
+
+# Read-only. Nothing here may be given `id-token: write` — the drift check reads the
+# production Space, and a token that can write it has no business in a reporting job.
+on:
+  push:
+    branches: [main]
+    # Not a YAML anchor — GitHub's workflow parser does not resolve aliases.
+    paths:
+      - "scripts/**"
+      - "tests/**"
+      - "space_template/**"
+      - "pyproject.toml"
+      - ".github/workflows/space-config.yml"
+  pull_request:
+    paths:
+      - "scripts/**"
+      - "tests/**"
+      - "space_template/**"
+      - "pyproject.toml"
+      - ".github/workflows/space-config.yml"
+  schedule:
+    # Weekly, so a Space edited by hand surfaces without waiting for the next deploy.
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - run: pip install -q 'huggingface_hub==1.26.0' pytest pyyaml
+
+      - run: pytest
+
+  drift:
+    # The template is only honest if something compares it to the live Spaces.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - run: pip install -q 'huggingface_hub==1.26.0' pyyaml
+
+      # Anonymous: both Spaces are public, so the job needs no credential at all.
+      - run: python scripts/check_space_config.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,12 +117,25 @@ there only because `duplicate_space()` **creates** `extralit-dev/pr-N`, and a tr
 publisher can only be registered on a repo that already exists. So it is `extralit-dev`-only
 by construction; no stored credential can reach `extralit/public-demo`.
 
-Two traps when editing that job. The `id-token: write` grant belongs on **`deploy-space`,
+**`deploy-space` deploys by committing, not by restarting.** It rewrites the Space's
+`Dockerfile` `FROM` line to the **digest** the `build` job just pushed and commits that; HF
+rebuilds on the new commit. Two independent reasons it works this way, and neither is
+negotiable:
+
+1. **`POST /api/spaces/…/restart` rejects OIDC tokens with a 401.** A repo publisher grants
+   *write access to the repo*; restarting is a runtime operation, not a repo write. Commits
+   are what the credential is actually for. (The exchange itself succeeds — a 401 here comes
+   from the restart endpoint, not from auth setup. A misconfigured publisher fails earlier and
+   differently, as `OIDCError`/`invalid_grant`.)
+2. **A digest cannot go stale.** These Spaces are a thin `FROM <pushed image>`; when that
+   line was a *tag*, HF reused the base image it had already built and shipped v0.7.0 as
+   0.6.1 with a green job. Changed content forces a real rebuild, which is why no
+   `factory_reboot` equivalent is needed anymore.
+
+The one trap when editing the job: the `id-token: write` grant belongs on **`deploy-space`,
 not at the top of the file** — every job here matches the publisher's repo/branch/workflow
 claims, so a workflow-level grant would hand `deploy-pr-space` the ability to mint a
-production token. And the restart must stay `factory_reboot=True`: a plain restart reuses
-the image HF already built without re-pulling the `FROM` base, which ships a green deploy of
-the previous version (that was v0.7.0).
+production token.
 
 **Variables and secrets differ here.** Adding an `EXTRALIT_*` environment *variable* is all
 it takes to reach a preview — the whole `vars` set is passed through. An `EXTRALIT_*`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,36 @@ behind a 45-minute `wait_for_space`.
 `scripts/types.py`, or `scripts/logging.py`** — the same mechanism would shadow those stdlib
 modules for `huggingface_hub`'s transitive dependencies.
 
+### `space_template/` and the `__VAR__` placeholder
+
+`space_template/` holds what a *new* Space should contain — `README.md`, `Dockerfile`,
+`.oauth.yaml`, and a `manifest.json` listing the files, the variables, and their defaults.
+It exists because `duplicate_space` copies **per-Space** config: anyone duplicating
+`extralit/public-demo` inherits extralit's `allowed_workspaces`, which are workspaces they do
+not have. So overwriting `README.md` and `.oauth.yaml` after creation is required, not tidier.
+
+`manifest.json` deliberately carries no `required_secrets`. That contract lives in the Hub's
+`deployment_templates.required_secrets` and is consumed by four routes; a second copy here
+has no seeder, and the drift surfaces as a user's Space silently missing a secret.
+
+Placeholders are `__VAR__`, and the alternatives are all worse:
+
+- `{{VAR}}` — an unquoted YAML plain scalar starting with `{` is a flow mapping, so the
+  unrendered `.oauth.yaml` would fail pre-commit's `check-yaml` (which runs with no path
+  filters).
+- `${VAR}` — collides with Dockerfile `ARG`/`ENV` expansion.
+- `string.Template.safe_substitute` — unknown placeholders pass through silently, which *is*
+  the silent-wipe failure mode.
+
+`__VAR__` is a valid YAML plain scalar and a valid Dockerfile literal, `hf_space.render`
+raises on any placeholder it was not given a value for, and the whole thing is a two-line
+regex in Python and in TypeScript, with no library either side.
+
+`scripts/check_space_config.py` is what keeps the template from becoming a file that looks
+authoritative but is inert: it renders with each live Space's variables and diffs, comparing
+parsed YAML rather than bytes and ignoring the `Dockerfile` `FROM` line that CI owns. It is
+**report-only and must stay outside any job holding `id-token: write`.**
+
 **Variables and secrets differ here.** Adding an `EXTRALIT_*` environment *variable* is all
 it takes to reach a preview — the whole `vars` set is passed through. An `EXTRALIT_*`
 *secret* must additionally be named in `build-hf-space.yml`'s `ALL_SECRETS` object. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,13 @@ runtime; `scripts/start.sh` re-exports them as the `OAUTH2_HUGGINGFACE_*` names 
 expects. The one exception is the source Space `extralit-dev/develop`, whose *custom* OAuth
 app is pinned to its own callback URL and therefore does not carry over to previews.
 
+`hf_oauth: true` is only half of it. Those injected variables are consumed only if the image
+contains `/home/extralit/.oauth.yaml` — `SecuritySettings` falls through to a bare
+`OAuth2Settings()` when the file is missing, and `_build_providers({}, [])` returns no
+providers, so the server registers nothing and the login button never appears. The file is
+put there by the `COPY .oauth.yaml /home/extralit/` line in each Space's own `Dockerfile`,
+which is why nothing may replace that file wholesale — only the `FROM` line is rewritten.
+
 
 **HF Spaces Production (`extralit-hf-space/`):**
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,19 @@ green — the same silent-wrong-result class the digest pin exists to prevent. I
 destroy `deploy_pinned_image`'s `after == before` skip branch, putting every no-op redeploy
 behind a 45-minute `wait_for_space`.
 
+**Waiting is two steps, and collapsing them re-opens the bug.** `deploy_pinned_image` polls
+until it sees a *build* stage before calling `wait_for_space`, because `wait_for_space` returns
+at the first non-build poll — which, in the seconds before the Hub schedules the commit's
+build, is still the stage from *before* it. Waiting directly would green-light the previous
+image. There is nothing cheaper to check: the runtime API reports no revision (`stage`,
+`hardware`, `gcTimeout`, `replicas`, `devMode`, `domains`), so an observed build transition is
+the only available proof the commit took effect.
+
+**`SLEEPING` counts as success.** It is absent from `SpaceStage` in `huggingface_hub` 1.26.0,
+so it arrives as a bare string, and it is where an idle Space sits between deploys
+(`gcTimeout` is 48h) — `extralit-dev/develop` is usually in it. It means the build succeeded
+and the Space was later garbage-collected, so rejecting it fails a deploy that worked.
+
 `scripts/` is on `sys.path[0]` for anything run as `python scripts/<name>.py`, which is how
 `import hf_space` resolves with no packaging. **Never add `scripts/secrets.py`,
 `scripts/types.py`, or `scripts/logging.py`** — the same mechanism would shadow those stdlib

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,28 @@ not at the top of the file** — every job here matches the publisher's repo/bra
 claims, so a workflow-level grant would hand `deploy-pr-space` the ability to mint a
 production token.
 
+### Update vs. create — the split that keeps production config alive
+
+Both deploy jobs share `scripts/hf_space.py`, but they are allowed to write different things:
+
+| Path | Operation | May write |
+| --- | --- | --- |
+| `deploy-space` (prod/staging) | **update** an existing Space | the `Dockerfile` `FROM` line, and nothing else |
+| `deploy-pr-space` (previews) | **create**, then update | the full template on create; the `FROM` line thereafter |
+
+**`deploy-space` must never render a template.** `.oauth.yaml` is not in this repo — it lives
+only in the Space repos, and its `allowed_workspaces` differ per Space (`public-demo`:
+`itn-recalibration`, `extralit`; `develop`: `public`, `test`). Rendering would wipe those and
+the README frontmatter, and the Space would still reach `RUNNING` and the job would still go
+green — the same silent-wrong-result class the digest pin exists to prevent. It would also
+destroy `deploy_pinned_image`'s `after == before` skip branch, putting every no-op redeploy
+behind a 45-minute `wait_for_space`.
+
+`scripts/` is on `sys.path[0]` for anything run as `python scripts/<name>.py`, which is how
+`import hf_space` resolves with no packaging. **Never add `scripts/secrets.py`,
+`scripts/types.py`, or `scripts/logging.py`** — the same mechanism would shadow those stdlib
+modules for `huggingface_hub`'s transitive dependencies.
+
 **Variables and secrets differ here.** Adding an `EXTRALIT_*` environment *variable* is all
 it takes to reach a preview — the whole `vars` set is passed through. An `EXTRALIT_*`
 *secret* must additionally be named in `build-hf-space.yml`'s `ALL_SECRETS` object. The

--- a/README.md
+++ b/README.md
@@ -164,6 +164,61 @@ docker build -t extralit-hf-space .
 docker run -p 80:80 extralit-hf-space
 ```
 
+## ⚙️ GitHub Workflows
+
+Three workflows cover this repository. One builds the image and deploys the live Spaces, one boots the container and health-checks it, and one guards the Space configuration.
+
+### Building and deploying (`build-hf-space.yml`)
+
+The monorepo's release pipeline drives this workflow through a `repository_dispatch` of type `build-hf-space`. There is no `push` trigger, so merging to `main` deploys nothing on its own; a manual `workflow_dispatch` always produces a staging build.
+
+**Inputs** arrive in the dispatch `client_payload`:
+
+| Field | Example | Effect |
+| --- | --- | --- |
+| `tag` | `v0.7.0`, `main` | Docker tag to build and push |
+| `branch` | `main`, `214/merge` | Chooses staging or a preview Space |
+| `is_release` | `true` / `false` | The only production signal |
+
+**Routing** happens in the `resolve-env` job. Branch names never select production; only `is_release` does, so a stray payload cannot reach the public demo.
+
+| Input | Environment | `:latest` | Platforms | Target Space |
+| --- | --- | :---: | --- | --- |
+| `is_release=true` | `production` | yes | amd64 + arm64 | `extralit/public-demo` |
+| `branch=main` | `staging` | yes | amd64 | `extralit-dev/develop` |
+| any other branch | `staging` | no | amd64 | `extralit-dev/pr-N` |
+| `workflow_dispatch` | `staging` | per ref | amd64 | per ref |
+
+**Outputs** are a multi-platform image on Docker Hub (`extralit/extralit-hf-space` for production, `extralitdev/extralit-hf-space` for staging) and a one-line commit to the target Space that repoints its `Dockerfile` `FROM` at the **image digest**, not a tag. A re-pushed tag lets HuggingFace reuse a base it has already built, which once shipped v0.7.0 while the Space still served 0.6.1. The job then blocks until the rebuild settles, so a `BUILD_ERROR` fails the run instead of reporting a green deploy.
+
+`deploy-space` carries no HuggingFace credential. It authenticates through [Trusted Publishers](https://huggingface.co/docs/hub/en/trusted-publishers), exchanging a GitHub OIDC token for one scoped to a single Space for an hour. The `id-token: write` grant sits on that job alone, so no other job can mint a production token.
+
+**Configuration** is scoped per GitHub environment:
+
+| Name | Kind | `production` | `staging` |
+| --- | --- | --- | --- |
+| `HF_SPACE_ID` | variable | `extralit/public-demo` | `extralit-dev/develop` |
+| `DOCKER_REPO` | variable | `extralit/extralit-hf-space` | `extralitdev/extralit-hf-space` |
+| `EXTRALIT_SERVER_IMAGE` | variable | `extralit/extralit-server` | `extralitdev/extralit-server` |
+| `DOCKER_USERNAME` / `DOCKER_PASSWORD` | secret | yes | yes |
+| `HF_TOKEN` | secret | none | preview Spaces only |
+
+`HF_TOKEN` survives only on `staging`. Trusted Publishers scope a token to a repository that already exists, and `duplicate_space()` creates `extralit-dev/pr-N` on demand, so preview creation cannot go keyless. Nothing stored anywhere in this repository can reach the production org.
+
+Preview Spaces get more than a retagged image. Duplicating copies files but not secrets or variables, so the job forwards the `staging` environment's `EXTRALIT_*` config onto the new Space and renders `README.md`, `.oauth.yaml`, and the `Dockerfile` from `space_template/`. Without that render the preview would inherit the source Space's workspace allowlist.
+
+### Testing the container (`integration-test.yml`)
+
+Pull requests and pushes touching `extralit_ocr/`, `scripts/`, `config/`, or the `Procfile` build the image and run it. The job waits for `/api/v1/status` to answer, checks the response parses as a JSON object, and probes the workspaces endpoint. It times out after 10 minutes and dumps container logs on failure.
+
+### Guarding the Space config (`space-config.yml`)
+
+Two jobs, neither of which may ever be given `id-token: write`.
+
+`unit-tests` runs `pytest` on any change to `scripts/`, `tests/`, `space_template/`, or `pyproject.toml`. It covers the pure logic that the deploy path depends on: the `FROM` rewrite preserving `COPY .oauth.yaml`, the `EXTRALIT_*` secret filter, and the stage handling that decides whether a Space actually rebuilt.
+
+`drift` runs weekly and on demand. It renders `space_template/` against each live Space and reports the differences, reading anonymously because both Spaces are public. It never writes. The check exists because `.oauth.yaml` lives only in the Space repositories, so a hand edit is invisible to git and a deletion is otherwise unrecoverable.
+
 ## 🔗 Next Steps
 
 - **Learn More**: [Extralit Documentation](https://docs.extralit.ai/latest/getting_started/quickstart/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,13 @@ packages = ["extralit_ocr"]
 dev = [
     "ruff",
     "rq-dashboard",
+    "pytest",
+    # Matches the version the deploy jobs pip-install, so tests hit the same API surface.
+    "huggingface_hub==1.26.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
 
 [tool.ruff]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "pytest",
     # Matches the version the deploy jobs pip-install, so tests hit the same API surface.
     "huggingface_hub==1.26.0",
+    "pyyaml",
 ]
 
 [tool.pytest.ini_options]

--- a/scripts/check_space_config.py
+++ b/scripts/check_space_config.py
@@ -103,7 +103,7 @@ def _fetch(api: HfApi, space_id: str, names) -> dict[str, str]:
     live = {}
     for name in names:
         try:
-            live[name] = Path(api.hf_hub_download(space_id, name, repo_type="space")).read_text()
+            live[name] = Path(api.hf_hub_download(space_id, name, repo_type="space")).read_text(encoding="utf-8")
         except EntryNotFoundError:
             continue
     return live

--- a/scripts/check_space_config.py
+++ b/scripts/check_space_config.py
@@ -67,9 +67,18 @@ def _frontmatter(text: str) -> dict:
     return front
 
 
-def _below_from(text: str) -> str:
-    body = [line for line in text.splitlines() if not line.startswith("FROM ")]
-    return "\n".join(body).strip()
+def _below_from(text: str) -> str | None:
+    """Drop only the first ``FROM`` line — the digest CI owns — or ``None`` if there is none.
+
+    Dropping every ``FROM`` would hide two real breakages, because ``pin_dockerfile`` rewrites
+    just the first: a Space carrying an extra later-stage ``FROM``, and one carrying none at
+    all (which makes the deploy job raise rather than pin).
+    """
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line.startswith("FROM "):
+            return "\n".join(lines[:index] + lines[index + 1 :]).strip()
+    return None
 
 
 def _diff_mappings(expected: dict, actual: dict) -> list[str]:
@@ -93,7 +102,11 @@ def compare(rendered: dict[str, str], live: dict[str, str]) -> dict[str, list[st
             messages = _diff_mappings(yaml.safe_load(expected) or {}, yaml.safe_load(live[name]) or {})
         else:
             # The FROM line is a digest the deploy job owns, so it is expected to differ.
-            messages = [] if _below_from(expected) == _below_from(live[name]) else ["differs below the FROM line"]
+            body = _below_from(live[name])
+            if body is None:
+                messages = ["no FROM line — deploy_pinned_image cannot pin this Space"]
+            else:
+                messages = [] if body == _below_from(expected) else ["differs below the FROM line"]
         if messages:
             drift[name] = messages
     return drift

--- a/scripts/check_space_config.py
+++ b/scripts/check_space_config.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+"""Report where the live Spaces have drifted from ``space_template/``. Never writes.
+
+``space_template/`` is only honest if something compares it to reality: nothing else in this
+repo renders it over the long-lived Spaces, and `deploy-space` deliberately never will. This
+also doubles as disaster recovery — a deleted ``.oauth.yaml`` is otherwise unrecoverable,
+since it exists only in the Space repos.
+
+Read-only by construction: it downloads, diffs, and prints. Keep it out of any job holding
+``id-token: write``.
+
+Flow:
+  1. Render ``space_template/`` once per Space in ``SPACES``, using that Space's variables.
+  2. Download the same files from the live Space.
+  3. Compare semantically — parsed YAML for ``README.md`` frontmatter and ``.oauth.yaml``,
+     text for the ``Dockerfile`` below its ``FROM`` line (which is a digest CI owns).
+  4. Print the drift and exit non-zero if there is any.
+
+Configuration is read entirely from environment variables:
+  HF_TOKEN (optional; the Spaces are public, so anonymous reads work)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import yaml
+from hf_space import render_space_files, workspaces_value
+from huggingface_hub import HfApi
+from huggingface_hub.errors import EntryNotFoundError
+
+TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "space_template"
+
+# What each long-lived Space is *supposed* to look like. Drift is either a Space someone
+# edited by hand or a stale entry here; the report does not presume which.
+SPACES = {
+    "extralit/public-demo": {
+        "COLOR_FROM": "blue",
+        "COLOR_TO": "green",
+        "LICENSE": "agpl-3.0",
+        "TAGS": "[data extraction]",
+        "HF_OAUTH": "false",
+        "WORKSPACES": workspaces_value(["itn-recalibration", "extralit"]),
+    },
+    "extralit-dev/develop": {
+        "COLOR_FROM": "purple",
+        "COLOR_TO": "red",
+        "LICENSE": "apache-2.0",
+        "TAGS": "[literature review, data extraction, llm]",
+        "HF_OAUTH": "false",
+        "WORKSPACES": workspaces_value(["public", "test"]),
+    },
+}
+
+
+def _frontmatter(text: str) -> dict:
+    parts = text.split("---")
+    front = yaml.safe_load(parts[1]) if len(parts) > 2 else {}
+    front = dict(front or {})
+    # Absent means off for both, so an omitted key is not drift.
+    front.setdefault("hf_oauth", False)
+    front.setdefault("pinned", False)
+    if isinstance(front.get("tags"), list):
+        front["tags"] = sorted(front["tags"])
+    return front
+
+
+def _below_from(text: str) -> str:
+    body = [line for line in text.splitlines() if not line.startswith("FROM ")]
+    return "\n".join(body).strip()
+
+
+def _diff_mappings(expected: dict, actual: dict) -> list[str]:
+    return [
+        f"{key}: expected {expected.get(key)!r}, live has {actual.get(key)!r}"
+        for key in sorted(set(expected) | set(actual))
+        if expected.get(key) != actual.get(key)
+    ]
+
+
+def compare(rendered: dict[str, str], live: dict[str, str]) -> dict[str, list[str]]:
+    """Return per-file drift messages; an empty dict means the Space matches the template."""
+    drift: dict[str, list[str]] = {}
+    for name, expected in rendered.items():
+        if name not in live:
+            drift[name] = ["missing from the live Space"]
+            continue
+        if name == "README.md":
+            messages = _diff_mappings(_frontmatter(expected), _frontmatter(live[name]))
+        elif name.endswith(".yaml"):
+            messages = _diff_mappings(yaml.safe_load(expected) or {}, yaml.safe_load(live[name]) or {})
+        else:
+            # The FROM line is a digest the deploy job owns, so it is expected to differ.
+            messages = [] if _below_from(expected) == _below_from(live[name]) else ["differs below the FROM line"]
+        if messages:
+            drift[name] = messages
+    return drift
+
+
+def _fetch(api: HfApi, space_id: str, names) -> dict[str, str]:
+    live = {}
+    for name in names:
+        try:
+            live[name] = Path(api.hf_hub_download(space_id, name, repo_type="space")).read_text()
+        except EntryNotFoundError:
+            continue
+    return live
+
+
+def main() -> None:
+    api = HfApi(token=os.environ.get("HF_TOKEN"))
+    drifted = False
+
+    for space_id, variables in SPACES.items():
+        rendered = render_space_files(TEMPLATE_DIR, {**variables, "IMAGE_REF": "unused"})
+        drift = compare(rendered, _fetch(api, space_id, rendered))
+        if not drift:
+            print(f"{space_id}: matches space_template/")
+            continue
+        drifted = True
+        print(f"{space_id}: DRIFT")
+        for name in sorted(drift):
+            for message in drift[name]:
+                print(f"  {name}: {message}")
+
+    if drifted:
+        # Report only — reconciling means editing the Space or SPACES above, by hand.
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy_pr_space.py
+++ b/scripts/deploy_pr_space.py
@@ -4,8 +4,9 @@
 Invoked by the ``deploy-pr-space`` job in ``.github/workflows/build-hf-space.yml``.
 
 Flow:
-  1. Duplicate ``SOURCE_SPACE`` -> ``<org>/<PR_SPACE_SLUG>`` on first run (writing a
-     minimal README), otherwise reuse the existing Space.
+  1. Duplicate ``SOURCE_SPACE`` -> ``<org>/<PR_SPACE_SLUG>`` on first run, then render
+     ``space_template/`` over the per-Space config the copy inherited. Otherwise reuse the
+     existing Space and leave its config alone.
   2. Propagate ``EXTRALIT_*`` config from the ``staging`` GitHub environment onto the Space.
      ``duplicate_space`` copies files but NOT secrets/variables, so without this a PR
      Space has no DB/S3/auth config. GitHub env *secrets* -> Space secrets; *variables*
@@ -25,24 +26,18 @@ Configuration is read entirely from environment variables:
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
-from hf_space import deploy_pinned_image, filter_prefixed
+from hf_space import deploy_pinned_image, filter_prefixed, render_space_files, workspaces_value
 from huggingface_hub import HfApi
 from huggingface_hub.errors import RepositoryNotFoundError
 
-PR_README = """\
----
-title: Extralit PR Preview
-emoji: '\U0001f4bb'
-colorFrom: purple
-colorTo: red
-sdk: docker
-app_port: 6900
-fullWidth: true
-license: apache-2.0
-hf_oauth: true
----
-"""
+TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "space_template"
+# Mirrors SOURCE_SPACE's own allowlist; the server creates these at startup if absent.
+PR_WORKSPACES = ["public", "test"]
+# The Dockerfile is rendered by deploy_pinned_image instead, so its upload is the one that
+# triggers the rebuild this job then waits on.
+CREATE_FILES = ["README.md", ".oauth.yaml"]
 
 
 def main() -> None:
@@ -66,13 +61,24 @@ def main() -> None:
             raise
         print(f"Creating '{target}' from '{source}'")
         api.duplicate_space(source, to_id=target, exist_ok=True, hardware="cpu-basic")
-        api.upload_file(
-            path_or_fileobj=PR_README.encode(),
-            path_in_repo="README.md",
-            repo_id=target,
-            repo_type="space",
-            commit_message="Enable HF OAuth",
+        # duplicate_space copies the source Space's README and allowlist verbatim, so the
+        # preview would otherwise run without hf_oauth and against the source's workspaces.
+        rendered = render_space_files(
+            TEMPLATE_DIR,
+            {
+                "TITLE": "Extralit PR Preview",
+                "WORKSPACES": workspaces_value(PR_WORKSPACES),
+                "IMAGE_REF": image_ref,
+            },
         )
+        for name in CREATE_FILES:
+            api.upload_file(
+                path_or_fileobj=rendered[name].encode(),
+                path_in_repo=name,
+                repo_id=target,
+                repo_type="space",
+                commit_message=f"Render {name} from space_template",
+            )
 
     space_secrets = filter_prefixed(os.environ.get("ALL_SECRETS", ""), "EXTRALIT_")
     space_vars = filter_prefixed(os.environ.get("ALL_VARS", ""), "EXTRALIT_")

--- a/scripts/deploy_pr_space.py
+++ b/scripts/deploy_pr_space.py
@@ -13,10 +13,10 @@ Flow:
      -> Space variables. Strictly filtered to ``EXTRALIT_*`` so ``HF_TOKEN`` / ``DOCKER_*``
      / the GitHub token are never pushed. Done BEFORE the Dockerfile upload so the first
      build already has the env present.
-  3. Rewrite the Space's ``Dockerfile`` ``FROM`` line to the digest ``build`` just pushed,
-     then wait for the rebuild to settle. Only that line — the rest of the file comes from
-     ``SOURCE_SPACE`` and carries ``COPY .oauth.yaml``, without which the server registers
-     no OAuth provider and ``hf_oauth: true`` is inert.
+  3. Settle the build. On create the rendered Dockerfile already carries the digest, so this
+     only waits; on later runs it rewrites the ``FROM`` line and waits for that rebuild. Only
+     that line is ever rewritten — the rest of the file carries ``COPY .oauth.yaml``, without
+     which the server registers no OAuth provider and ``hf_oauth: true`` is inert.
 
 Configuration is read entirely from environment variables:
   HF_TOKEN, SOURCE_SPACE, PR_SPACE_SLUG, DOCKER_REPO, IMAGE_DIGEST,
@@ -35,9 +35,9 @@ from huggingface_hub.errors import RepositoryNotFoundError
 TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "space_template"
 # Mirrors SOURCE_SPACE's own allowlist; the server creates these at startup if absent.
 PR_WORKSPACES = ["public", "test"]
-# The Dockerfile is rendered by deploy_pinned_image instead, so its upload is the one that
-# triggers the rebuild this job then waits on.
-CREATE_FILES = ["README.md", ".oauth.yaml"]
+# Every file the manifest declares: a duplicate inherits SOURCE_SPACE's, so anything left out
+# here silently carries that Space's drift into the preview instead of the committed template.
+CREATE_FILES = ["README.md", ".oauth.yaml", "Dockerfile"]
 
 
 def main() -> None:

--- a/scripts/deploy_pr_space.py
+++ b/scripts/deploy_pr_space.py
@@ -12,10 +12,13 @@ Flow:
      -> Space variables. Strictly filtered to ``EXTRALIT_*`` so ``HF_TOKEN`` / ``DOCKER_*``
      / the GitHub token are never pushed. Done BEFORE the Dockerfile upload so the first
      build already has the env present.
-  3. Upload a one-line ``Dockerfile`` pinning the Space to the PR's image tag.
+  3. Rewrite the Space's ``Dockerfile`` ``FROM`` line to the digest ``build`` just pushed,
+     then wait for the rebuild to settle. Only that line — the rest of the file comes from
+     ``SOURCE_SPACE`` and carries ``COPY .oauth.yaml``, without which the server registers
+     no OAuth provider and ``hf_oauth: true`` is inert.
 
 Configuration is read entirely from environment variables:
-  HF_TOKEN, SOURCE_SPACE, PR_SPACE_SLUG, DOCKER_REPO, IMAGE_TAG,
+  HF_TOKEN, SOURCE_SPACE, PR_SPACE_SLUG, DOCKER_REPO, IMAGE_DIGEST,
   ALL_SECRETS / ALL_VARS  (JSON objects, typically ``toJSON(secrets)``/``toJSON(vars)``).
 """
 
@@ -23,7 +26,7 @@ from __future__ import annotations
 
 import os
 
-from hf_space import filter_prefixed
+from hf_space import deploy_pinned_image, filter_prefixed
 from huggingface_hub import HfApi
 from huggingface_hub.errors import RepositoryNotFoundError
 
@@ -47,8 +50,8 @@ def main() -> None:
     source = os.environ["SOURCE_SPACE"]
     org = source.split("/")[0]
     target = f"{org}/{os.environ['PR_SPACE_SLUG']}"
-    docker_repo = os.environ["DOCKER_REPO"]
-    image_tag = os.environ["IMAGE_TAG"]
+    # A digest, not `:pr-N`: that tag is re-pushed every build, so HF can reuse a stale base.
+    image_ref = f"{os.environ['DOCKER_REPO']}@{os.environ['IMAGE_DIGEST']}"
 
     try:
         api.space_info(target)
@@ -82,15 +85,7 @@ def main() -> None:
         print(f"  variable -> {key}")
     print(f"Synced {len(space_secrets)} secret(s) + {len(space_vars)} variable(s) to {target}")
 
-    dockerfile = f"FROM {docker_repo}:{image_tag}\n"
-    api.upload_file(
-        path_or_fileobj=dockerfile.encode(),
-        path_in_repo="Dockerfile",
-        repo_id=target,
-        repo_type="space",
-        commit_message=f"Deploy {docker_repo}:{image_tag}",
-    )
-    print(f"Deployed {target} -> {docker_repo}:{image_tag}")
+    deploy_pinned_image(api, target, image_ref)
     print(f"URL: https://huggingface.co/spaces/{target}")
 
 

--- a/scripts/deploy_pr_space.py
+++ b/scripts/deploy_pr_space.py
@@ -21,9 +21,9 @@ Configuration is read entirely from environment variables:
 
 from __future__ import annotations
 
-import json
 import os
 
+from hf_space import filter_prefixed
 from huggingface_hub import HfApi
 from huggingface_hub.errors import RepositoryNotFoundError
 
@@ -40,15 +40,6 @@ license: apache-2.0
 hf_oauth: true
 ---
 """
-
-
-def _filter_extralit(raw: str) -> dict[str, str]:
-    """Parse a JSON object of env vars and keep only the ``EXTRALIT_*`` keys."""
-    try:
-        data = json.loads(raw) if raw else {}
-    except json.JSONDecodeError:
-        data = {}
-    return {k: v for k, v in data.items() if k.startswith("EXTRALIT_")}
 
 
 def main() -> None:
@@ -80,8 +71,8 @@ def main() -> None:
             commit_message="Enable HF OAuth",
         )
 
-    space_secrets = _filter_extralit(os.environ.get("ALL_SECRETS", ""))
-    space_vars = _filter_extralit(os.environ.get("ALL_VARS", ""))
+    space_secrets = filter_prefixed(os.environ.get("ALL_SECRETS", ""), "EXTRALIT_")
+    space_vars = filter_prefixed(os.environ.get("ALL_VARS", ""), "EXTRALIT_")
 
     for key in sorted(space_secrets):
         api.add_space_secret(repo_id=target, key=key, value=space_secrets[key], description="from CI staging env")

--- a/scripts/deploy_space.py
+++ b/scripts/deploy_space.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""Pin the long-lived prod/staging Space to the image the ``build`` job just pushed.
+
+Invoked by the ``deploy-space`` job in ``.github/workflows/build-hf-space.yml``, which
+authenticates keylessly via Trusted Publishers (``HF_OIDC_RESOURCE`` + ``id-token: write``);
+``HfApi()`` picks that exchange up with no token argument.
+
+Flow:
+  1. Download the Space's current ``Dockerfile``.
+  2. Rewrite its ``FROM`` line to ``DOCKER_REPO@IMAGE_DIGEST`` — the *only* line touched, so
+     the Space's own ``COPY .oauth.yaml`` / ``ENV`` lines and README stay as they are. This
+     job updates an existing Space; it must never render a template over one.
+  3. Commit if that changed anything, then wait for the rebuild to settle in ``RUNNING``.
+
+Configuration is read entirely from environment variables:
+  HF_SPACE_ID, DOCKER_REPO, IMAGE_DIGEST
+"""
+
+from __future__ import annotations
+
+import os
+
+from hf_space import deploy_pinned_image
+from huggingface_hub import HfApi
+
+
+def main() -> None:
+    space_id = os.environ["HF_SPACE_ID"]
+    # A digest, not a tag: a re-pushed tag lets HF reuse a stale base and ship the wrong version.
+    image_ref = f"{os.environ['DOCKER_REPO']}@{os.environ['IMAGE_DIGEST']}"
+    deploy_pinned_image(HfApi(), space_id, image_ref)
+    print(f"URL: https://huggingface.co/spaces/{space_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/deploy_space.py
+++ b/scripts/deploy_space.py
@@ -10,7 +10,7 @@ Flow:
   2. Rewrite its ``FROM`` line to ``DOCKER_REPO@IMAGE_DIGEST`` — the *only* line touched, so
      the Space's own ``COPY .oauth.yaml`` / ``ENV`` lines and README stay as they are. This
      job updates an existing Space; it must never render a template over one.
-  3. Commit if that changed anything, then wait for the rebuild to settle in ``RUNNING``.
+  3. Commit if that changed anything, then wait for the rebuild to start and settle.
 
 Configuration is read entirely from environment variables:
   HF_SPACE_ID, DOCKER_REPO, IMAGE_DIGEST

--- a/scripts/hf_space.py
+++ b/scripts/hf_space.py
@@ -70,12 +70,12 @@ def workspaces_value(names) -> str:
 def render_space_files(template_dir, variables: dict[str, str]) -> dict[str, str]:
     """Render every file ``manifest.json`` lists, keyed by its path in the Space repo."""
     root = Path(template_dir)
-    manifest = json.loads((root / "manifest.json").read_text())
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
     values = {**manifest.get("defaults", {}), **variables}
     missing = sorted(set(manifest["variables"]) - set(values))
     if missing:
         raise KeyError(f"Template variables without a value: {missing}")
-    return {name: render((root / name).read_text(), values) for name in manifest["files"]}
+    return {name: render((root / name).read_text(encoding="utf-8"), values) for name in manifest["files"]}
 
 
 def deploy_pinned_image(api, space_id: str, image_ref: str):
@@ -83,7 +83,7 @@ def deploy_pinned_image(api, space_id: str, image_ref: str):
 
     Commit-to-rebuild, not ``restart_space``: the restart API rejects OIDC tokens with a 401.
     """
-    with open(api.hf_hub_download(space_id, "Dockerfile", repo_type="space")) as fh:
+    with open(api.hf_hub_download(space_id, "Dockerfile", repo_type="space"), encoding="utf-8") as fh:
         before = fh.read()
     after = pin_dockerfile(before, image_ref)
 

--- a/scripts/hf_space.py
+++ b/scripts/hf_space.py
@@ -14,10 +14,14 @@ from __future__ import annotations
 import json
 import re
 import time
+from pathlib import Path
 
 from huggingface_hub import SpaceStage
 
 _FROM_LINE = re.compile(r"^FROM\s+\S+", re.M)
+# `__VAR__`, not `{{VAR}}` (an unquoted `{` starts a YAML flow mapping, so the unrendered
+# .oauth.yaml would fail pre-commit's check-yaml) and not `${VAR}` (Dockerfile ARG/ENV).
+_PLACEHOLDER = re.compile(r"__([A-Z0-9_]+)__")
 
 
 def filter_prefixed(raw: str, prefix: str) -> dict[str, str]:
@@ -39,6 +43,39 @@ def pin_dockerfile(text: str, image_ref: str) -> str:
     if not found:
         raise ValueError("No FROM line to pin in the Dockerfile")
     return out
+
+
+def render(text: str, variables: dict[str, str]) -> str:
+    """Substitute every ``__VAR__`` in ``text``, raising on one that has no value.
+
+    Deliberately not ``string.Template.safe_substitute``: an unresolved placeholder passing
+    through silently is the failure mode that ships a broken Space config.
+    """
+
+    def value_for(match: re.Match) -> str:
+        name = match.group(1)
+        try:
+            return variables[name]
+        except KeyError:
+            raise KeyError(f"No value for template placeholder __{name}__") from None
+
+    return _PLACEHOLDER.sub(value_for, text)
+
+
+def workspaces_value(names) -> str:
+    """Format workspace names as the YAML flow sequence ``allowed_workspaces`` expects."""
+    return "[" + ", ".join(f"{{name: {name}}}" for name in names) + "]"
+
+
+def render_space_files(template_dir, variables: dict[str, str]) -> dict[str, str]:
+    """Render every file ``manifest.json`` lists, keyed by its path in the Space repo."""
+    root = Path(template_dir)
+    manifest = json.loads((root / "manifest.json").read_text())
+    values = {**manifest.get("defaults", {}), **variables}
+    missing = sorted(set(manifest["variables"]) - set(values))
+    if missing:
+        raise KeyError(f"Template variables without a value: {missing}")
+    return {name: render((root / name).read_text(), values) for name in manifest["files"]}
 
 
 def deploy_pinned_image(api, space_id: str, image_ref: str):

--- a/scripts/hf_space.py
+++ b/scripts/hf_space.py
@@ -23,6 +23,17 @@ _FROM_LINE = re.compile(r"^FROM\s+\S+", re.M)
 # .oauth.yaml would fail pre-commit's check-yaml) and not `${VAR}` (Dockerfile ARG/ENV).
 _PLACEHOLDER = re.compile(r"__([A-Z0-9_]+)__")
 
+BUILD_STAGES = (
+    SpaceStage.BUILDING,
+    SpaceStage.RUNNING_BUILDING,
+    SpaceStage.APP_STARTING,
+    SpaceStage.RUNNING_APP_STARTING,
+)
+# The runtime API returns SLEEPING for a gc'd Space, but SpaceStage has no such member, so it
+# arrives as a bare string. It means the build succeeded and the Space has since gone idle.
+SLEEPING = "SLEEPING"
+SETTLED_OK = (SpaceStage.RUNNING, SLEEPING)
+
 
 def filter_prefixed(raw: str, prefix: str) -> dict[str, str]:
     """Parse a JSON object of env vars and keep only the keys carrying ``prefix``."""
@@ -78,8 +89,24 @@ def render_space_files(template_dir, variables: dict[str, str]) -> dict[str, str
     return {name: render((root / name).read_text(encoding="utf-8"), values) for name in manifest["files"]}
 
 
+def await_rebuild(api, space_id: str, *, attempts: int = 60, poll_interval: int = 10):
+    """Block until a build starts, then until it settles. Raises if none ever starts.
+
+    Waiting directly would accept the stage from *before* the commit: the Hub takes a while to
+    schedule the build, and ``wait_for_space`` returns at the first non-build poll. Requiring an
+    observed build stage first is the only available proof the commit took effect — the runtime
+    API reports no revision, so there is nothing to match the pushed commit against.
+    """
+    for _ in range(attempts):
+        runtime = api.get_space_runtime(space_id)
+        if runtime.stage in BUILD_STAGES:
+            return api.wait_for_space(space_id, timeout=2700, poll_interval=poll_interval)
+        time.sleep(poll_interval)
+    raise RuntimeError(f"Deploy failed: {space_id} never started building (stage {runtime.stage})")
+
+
 def deploy_pinned_image(api, space_id: str, image_ref: str):
-    """Point ``space_id``'s Dockerfile at ``image_ref`` and block until it is RUNNING.
+    """Point ``space_id``'s Dockerfile at ``image_ref`` and block until the build settles.
 
     Commit-to-rebuild, not ``restart_space``: the restart API rejects OIDC tokens with a 401.
     """
@@ -88,9 +115,12 @@ def deploy_pinned_image(api, space_id: str, image_ref: str):
     after = pin_dockerfile(before, image_ref)
 
     if after == before:
-        # Already serving this ref, so a no-op commit would trigger no rebuild to wait for.
         print(f"{space_id} already pinned to {image_ref}")
         runtime = api.get_space_runtime(space_id)
+        if runtime.stage in BUILD_STAGES:
+            # A build is already in flight — on the create path the template upload pinned the
+            # digest, so this branch owns the wait that the upload branch would otherwise do.
+            runtime = api.wait_for_space(space_id, timeout=2700, poll_interval=10)
     else:
         print(f"Pinning {space_id} to {image_ref}")
         api.upload_file(
@@ -100,12 +130,10 @@ def deploy_pinned_image(api, space_id: str, image_ref: str):
             repo_type="space",
             commit_message=f"Deploy {image_ref}",
         )
-        # wait_for_space returns at the first non-build poll, which is the stale RUNNING.
-        time.sleep(30)
-        runtime = api.wait_for_space(space_id, timeout=2700, poll_interval=10)
+        runtime = await_rebuild(api, space_id)
 
     print(f"Stage: {runtime.stage}")
     # The rebuild is async, so without this a BUILD_ERROR still reports a green deploy.
-    if runtime.stage != SpaceStage.RUNNING:
+    if runtime.stage not in SETTLED_OK:
         raise RuntimeError(f"Deploy failed: {space_id} settled in {runtime.stage}")
     return runtime

--- a/scripts/hf_space.py
+++ b/scripts/hf_space.py
@@ -1,0 +1,74 @@
+"""Shared helpers for deploying a Hugging Face Space to a freshly built image.
+
+Imported by ``deploy_space.py`` (updates an existing Space) and ``deploy_pr_space.py``
+(creates then updates an ephemeral preview Space). Both run as ``python scripts/<name>.py``,
+which puts this directory on ``sys.path[0]``, so a plain ``import hf_space`` resolves with no
+packaging.
+
+  Never add ``scripts/secrets.py``, ``scripts/types.py`` or ``scripts/logging.py`` — the same
+  mechanism would shadow those stdlib modules for ``huggingface_hub``'s transitive deps.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+
+from huggingface_hub import SpaceStage
+
+_FROM_LINE = re.compile(r"^FROM\s+\S+", re.M)
+
+
+def filter_prefixed(raw: str, prefix: str) -> dict[str, str]:
+    """Parse a JSON object of env vars and keep only the keys carrying ``prefix``."""
+    try:
+        data = json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        data = {}
+    return {k: v for k, v in data.items() if k.startswith(prefix)}
+
+
+def pin_dockerfile(text: str, image_ref: str) -> str:
+    """Rewrite the first ``FROM`` line to ``image_ref``, leaving every other byte alone.
+
+    Rewriting rather than replacing the file is what keeps a Space's own
+    ``COPY .oauth.yaml`` / ``ENV`` lines — and therefore its HF login — alive.
+    """
+    out, found = _FROM_LINE.subn(lambda _m: f"FROM {image_ref}", text, count=1)
+    if not found:
+        raise ValueError("No FROM line to pin in the Dockerfile")
+    return out
+
+
+def deploy_pinned_image(api, space_id: str, image_ref: str):
+    """Point ``space_id``'s Dockerfile at ``image_ref`` and block until it is RUNNING.
+
+    Commit-to-rebuild, not ``restart_space``: the restart API rejects OIDC tokens with a 401.
+    """
+    with open(api.hf_hub_download(space_id, "Dockerfile", repo_type="space")) as fh:
+        before = fh.read()
+    after = pin_dockerfile(before, image_ref)
+
+    if after == before:
+        # Already serving this ref, so a no-op commit would trigger no rebuild to wait for.
+        print(f"{space_id} already pinned to {image_ref}")
+        runtime = api.get_space_runtime(space_id)
+    else:
+        print(f"Pinning {space_id} to {image_ref}")
+        api.upload_file(
+            path_or_fileobj=after.encode(),
+            path_in_repo="Dockerfile",
+            repo_id=space_id,
+            repo_type="space",
+            commit_message=f"Deploy {image_ref}",
+        )
+        # wait_for_space returns at the first non-build poll, which is the stale RUNNING.
+        time.sleep(30)
+        runtime = api.wait_for_space(space_id, timeout=2700, poll_interval=10)
+
+    print(f"Stage: {runtime.stage}")
+    # The rebuild is async, so without this a BUILD_ERROR still reports a green deploy.
+    if runtime.stage != SpaceStage.RUNNING:
+        raise RuntimeError(f"Deploy failed: {space_id} settled in {runtime.stage}")
+    return runtime

--- a/space_template/.oauth.yaml
+++ b/space_template/.oauth.yaml
@@ -1,0 +1,8 @@
+# Change to `false` to disable HF auth integration
+enabled: true
+
+providers:
+  - name: huggingface
+
+# Workspaces are created at startup if they do not exist yet.
+allowed_workspaces: __WORKSPACES__

--- a/space_template/Dockerfile
+++ b/space_template/Dockerfile
@@ -1,0 +1,7 @@
+FROM __IMAGE_REF__
+
+# Copy the auth config section
+COPY .oauth.yaml /home/extralit/
+
+# Uncoment this line to remove the persistence storage warning
+ENV EXTRALIT_SHOW_HUGGINGFACE_SPACE_PERSISTENT_STORAGE_WARNING=false

--- a/space_template/README.md
+++ b/space_template/README.md
@@ -1,0 +1,15 @@
+---
+title: __TITLE__
+emoji: __EMOJI__
+colorFrom: __COLOR_FROM__
+colorTo: __COLOR_TO__
+sdk: docker
+pinned: true
+app_port: 6900
+fullWidth: true
+license: __LICENSE__
+hf_oauth: __HF_OAUTH__
+tags: __TAGS__
+---
+
+Check out the configuration reference at https://huggingface.co/docs/hub/spaces-config-reference

--- a/space_template/manifest.json
+++ b/space_template/manifest.json
@@ -1,0 +1,24 @@
+{
+  "files": ["README.md", "Dockerfile", ".oauth.yaml"],
+  "variables": [
+    "TITLE",
+    "EMOJI",
+    "COLOR_FROM",
+    "COLOR_TO",
+    "LICENSE",
+    "TAGS",
+    "HF_OAUTH",
+    "WORKSPACES",
+    "IMAGE_REF"
+  ],
+  "defaults": {
+    "TITLE": "Extralit",
+    "EMOJI": "💻",
+    "COLOR_FROM": "purple",
+    "COLOR_TO": "red",
+    "LICENSE": "apache-2.0",
+    "TAGS": "[data extraction, literature review, llm]",
+    "HF_OAUTH": "true",
+    "WORKSPACES": "[{name: default}]"
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Make ``scripts/`` importable from tests.
+
+Not ``[tool.pytest.ini_options] pythonpath``: that resolves against pytest's rootdir, which
+moves the moment this repo is run as a submodule of the ``extralit`` monorepo.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))

--- a/tests/test_check_space_config.py
+++ b/tests/test_check_space_config.py
@@ -53,6 +53,29 @@ def test_dockerfile_drift_below_the_from_line_is_reported():
     assert list(drift) == ["Dockerfile"]
 
 
+def test_a_dockerfile_without_a_from_line_is_reported():
+    # pin_dockerfile raises on this, so the deploy job would hard-fail; say so here first.
+    live = dict(RENDERED, **{"Dockerfile": "COPY .oauth.yaml /home/extralit/\n"})
+
+    drift = check.compare(RENDERED, live)
+
+    assert list(drift) == ["Dockerfile"]
+    assert "no FROM line" in drift["Dockerfile"][0]
+
+
+def test_an_extra_later_stage_from_is_reported():
+    # Only the first FROM is CI's to own. Dropping every FROM would normalize this to the
+    # expected body and report no drift on a Space that grew a second build stage.
+    live = dict(
+        RENDERED,
+        **{"Dockerfile": "FROM repo@sha256:bbb\n\nCOPY .oauth.yaml /home/extralit/\nFROM scratch\n"},
+    )
+
+    drift = check.compare(RENDERED, live)
+
+    assert list(drift) == ["Dockerfile"]
+
+
 def test_a_file_missing_from_the_live_space_is_drift():
     live = {k: v for k, v in RENDERED.items() if k != ".oauth.yaml"}
 

--- a/tests/test_check_space_config.py
+++ b/tests/test_check_space_config.py
@@ -1,0 +1,73 @@
+"""Tests for ``scripts/check_space_config.py`` — the read-only template drift check."""
+
+from __future__ import annotations
+
+import check_space_config as check
+
+RENDERED = {
+    "README.md": "---\ntitle: Extralit\nhf_oauth: false\ntags: [b, a]\n---\n\nbody\n",
+    ".oauth.yaml": "enabled: true\nallowed_workspaces: [{name: public}]\n",
+    "Dockerfile": "FROM repo@sha256:aaa\n\nCOPY .oauth.yaml /home/extralit/\n",
+}
+
+
+def test_no_drift_when_the_live_space_matches_semantically():
+    live = {
+        # Block style, different key order, tags in the other order — same meaning.
+        "README.md": "---\ntags:\n- a\n- b\ntitle: Extralit\n---\n\nbody\n",
+        ".oauth.yaml": "enabled: true\nallowed_workspaces:\n  - name: public\n",
+        "Dockerfile": "FROM repo@sha256:bbb\n\nCOPY .oauth.yaml /home/extralit/\n",
+    }
+
+    assert check.compare(RENDERED, live) == {}
+
+
+def test_frontmatter_drift_is_reported_per_key():
+    live = dict(RENDERED, **{"README.md": "---\ntitle: Something Else\nhf_oauth: false\ntags: [a, b]\n---\n"})
+
+    drift = check.compare(RENDERED, live)
+
+    assert list(drift) == ["README.md"]
+    assert any("title" in line for line in drift["README.md"])
+
+
+def test_allowlist_drift_is_reported():
+    live = dict(RENDERED, **{".oauth.yaml": "enabled: true\nallowed_workspaces:\n  - name: extralit\n"})
+
+    drift = check.compare(RENDERED, live)
+
+    assert list(drift) == [".oauth.yaml"]
+
+
+def test_dockerfile_drift_ignores_the_from_line():
+    live = dict(RENDERED, **{"Dockerfile": "FROM other@sha256:ccc\n\nCOPY .oauth.yaml /home/extralit/\n"})
+
+    assert check.compare(RENDERED, live) == {}
+
+
+def test_dockerfile_drift_below_the_from_line_is_reported():
+    live = dict(RENDERED, **{"Dockerfile": "FROM repo@sha256:aaa\n"})
+
+    drift = check.compare(RENDERED, live)
+
+    assert list(drift) == ["Dockerfile"]
+
+
+def test_a_file_missing_from_the_live_space_is_drift():
+    live = {k: v for k, v in RENDERED.items() if k != ".oauth.yaml"}
+
+    drift = check.compare(RENDERED, live)
+
+    assert list(drift) == [".oauth.yaml"]
+
+
+def test_every_configured_space_declares_the_variables_the_template_needs():
+    from pathlib import Path
+
+    from hf_space import render_space_files
+
+    template = Path(__file__).resolve().parent.parent / "space_template"
+    for variables in check.SPACES.values():
+        # Raises KeyError on any placeholder this Space has no value for.
+        files = render_space_files(template, {**variables, "IMAGE_REF": "r@sha256:a"})
+        assert set(files) == {"README.md", "Dockerfile", ".oauth.yaml"}

--- a/tests/test_deploy_pr_space.py
+++ b/tests/test_deploy_pr_space.py
@@ -1,0 +1,81 @@
+"""Tests for ``scripts/deploy_pr_space.py`` — preview Space create-then-pin."""
+
+from __future__ import annotations
+
+import json
+
+import deploy_pr_space
+import pytest
+
+
+class FakeApi:
+    def __init__(self, exists=True):
+        self._exists = exists
+        self.duplicated = []
+        self.uploads = []
+        self.secrets = {}
+        self.variables = {}
+
+    def space_info(self, repo_id):
+        if not self._exists:
+            raise deploy_pr_space.RepositoryNotFoundError("404")
+        return {"id": repo_id}
+
+    def duplicate_space(self, source, to_id=None, exist_ok=False, hardware=None):
+        self.duplicated.append((source, to_id))
+
+    def upload_file(self, *, path_or_fileobj, path_in_repo, repo_id, repo_type, commit_message):
+        self.uploads.append((path_in_repo, path_or_fileobj.decode()))
+
+    def add_space_secret(self, repo_id, key, value, description=None):
+        self.secrets[key] = value
+
+    def add_space_variable(self, repo_id, key, value, description=None):
+        self.variables[key] = value
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.setenv("HF_TOKEN", "hf_x")
+    monkeypatch.setenv("SOURCE_SPACE", "extralit-dev/develop")
+    monkeypatch.setenv("PR_SPACE_SLUG", "pr-42")
+    monkeypatch.setenv("DOCKER_REPO", "extralitdev/extralit-hf-space")
+    monkeypatch.setenv("IMAGE_DIGEST", "sha256:" + "c" * 64)
+    monkeypatch.setenv("ALL_SECRETS", "{}")
+    monkeypatch.setenv("ALL_VARS", json.dumps({"EXTRALIT_S3_ENDPOINT": "https://s3", "DOCKER_REPO": "nope"}))
+
+
+def _install(monkeypatch, api):
+    pins = []
+    monkeypatch.setattr(deploy_pr_space, "HfApi", lambda token=None: api)
+    monkeypatch.setattr(deploy_pr_space, "deploy_pinned_image", lambda *args: pins.append(args))
+    return pins
+
+
+def test_main_pins_the_preview_by_digest_not_by_tag(env, monkeypatch):
+    api = FakeApi(exists=True)
+    pins = _install(monkeypatch, api)
+
+    deploy_pr_space.main()
+
+    assert pins == [(api, "extralit-dev/pr-42", "extralitdev/extralit-hf-space@sha256:" + "c" * 64)]
+
+
+def test_main_never_overwrites_the_duplicated_dockerfile(env, monkeypatch):
+    api = FakeApi(exists=True)
+    _install(monkeypatch, api)
+
+    deploy_pr_space.main()
+
+    # A whole-file Dockerfile write drops the source Space's `COPY .oauth.yaml`, which
+    # silently disables HF login on the preview. Only deploy_pinned_image may touch it.
+    assert [path for path, _ in api.uploads if path == "Dockerfile"] == []
+
+
+def test_main_still_propagates_only_extralit_vars(env, monkeypatch):
+    api = FakeApi(exists=True)
+    _install(monkeypatch, api)
+
+    deploy_pr_space.main()
+
+    assert api.variables == {"EXTRALIT_S3_ENDPOINT": "https://s3"}

--- a/tests/test_deploy_pr_space.py
+++ b/tests/test_deploy_pr_space.py
@@ -8,6 +8,13 @@ import deploy_pr_space
 import pytest
 
 
+class _Response:
+    def __init__(self, status_code):
+        self.status_code = status_code
+        self.headers = {}
+        self.request = None
+
+
 class FakeApi:
     def __init__(self, exists=True):
         self._exists = exists
@@ -18,7 +25,7 @@ class FakeApi:
 
     def space_info(self, repo_id):
         if not self._exists:
-            raise deploy_pr_space.RepositoryNotFoundError("404")
+            raise deploy_pr_space.RepositoryNotFoundError("404", response=_Response(404))
         return {"id": repo_id}
 
     def duplicate_space(self, source, to_id=None, exist_ok=False, hardware=None):
@@ -70,6 +77,36 @@ def test_main_never_overwrites_the_duplicated_dockerfile(env, monkeypatch):
     # A whole-file Dockerfile write drops the source Space's `COPY .oauth.yaml`, which
     # silently disables HF login on the preview. Only deploy_pinned_image may touch it.
     assert [path for path, _ in api.uploads if path == "Dockerfile"] == []
+
+
+def test_main_renders_the_template_over_the_duplicated_config(env, monkeypatch):
+    import yaml
+
+    api = FakeApi(exists=False)
+    _install(monkeypatch, api)
+
+    deploy_pr_space.main()
+
+    written = dict(api.uploads)
+    assert api.duplicated == [("extralit-dev/develop", "extralit-dev/pr-42")]
+
+    front = yaml.safe_load(written["README.md"].split("---")[1])
+    assert front["hf_oauth"] is True
+
+    # duplicate_space copies the source Space's allowlist verbatim; the preview must get
+    # its own, not inherit whatever the source happens to list today.
+    oauth = yaml.safe_load(written[".oauth.yaml"])
+    assert oauth["allowed_workspaces"] == [{"name": "public"}, {"name": "test"}]
+    assert oauth["providers"] == [{"name": "huggingface"}]
+
+
+def test_main_leaves_an_existing_preview_config_alone(env, monkeypatch):
+    api = FakeApi(exists=True)
+    _install(monkeypatch, api)
+
+    deploy_pr_space.main()
+
+    assert api.uploads == []
 
 
 def test_main_still_propagates_only_extralit_vars(env, monkeypatch):

--- a/tests/test_deploy_pr_space.py
+++ b/tests/test_deploy_pr_space.py
@@ -99,6 +99,12 @@ def test_main_renders_the_template_over_the_duplicated_config(env, monkeypatch):
     assert oauth["allowed_workspaces"] == [{"name": "public"}, {"name": "test"}]
     assert oauth["providers"] == [{"name": "huggingface"}]
 
+    # Rendered, not inherited: the copy would otherwise carry the source Space's Dockerfile.
+    # It arrives already pinned to the digest, and must keep the line that makes OAuth work.
+    dockerfile = written["Dockerfile"]
+    assert dockerfile.splitlines()[0] == "FROM extralitdev/extralit-hf-space@sha256:" + "c" * 64
+    assert "COPY .oauth.yaml /home/extralit/" in dockerfile
+
 
 def test_main_leaves_an_existing_preview_config_alone(env, monkeypatch):
     api = FakeApi(exists=True)

--- a/tests/test_deploy_space.py
+++ b/tests/test_deploy_space.py
@@ -1,0 +1,31 @@
+"""Tests for ``scripts/deploy_space.py`` — the env-to-image-ref glue."""
+
+from __future__ import annotations
+
+import deploy_space
+import pytest
+
+DIGEST = "sha256:" + "b" * 64
+
+
+def test_main_pins_the_space_to_a_digest_not_a_tag(monkeypatch):
+    calls = []
+    monkeypatch.setattr(deploy_space, "HfApi", lambda: "api")
+    monkeypatch.setattr(deploy_space, "deploy_pinned_image", lambda *args: calls.append(args))
+    monkeypatch.setenv("HF_SPACE_ID", "extralit/public-demo")
+    monkeypatch.setenv("DOCKER_REPO", "extralit/extralit-hf-space")
+    monkeypatch.setenv("IMAGE_DIGEST", DIGEST)
+
+    deploy_space.main()
+
+    assert calls == [("api", "extralit/public-demo", f"extralit/extralit-hf-space@{DIGEST}")]
+
+
+def test_main_fails_loudly_on_a_missing_digest(monkeypatch):
+    monkeypatch.setattr(deploy_space, "HfApi", lambda: "api")
+    monkeypatch.setenv("HF_SPACE_ID", "extralit/public-demo")
+    monkeypatch.setenv("DOCKER_REPO", "extralit/extralit-hf-space")
+    monkeypatch.delenv("IMAGE_DIGEST", raising=False)
+
+    with pytest.raises(KeyError):
+        deploy_space.main()

--- a/tests/test_hf_space.py
+++ b/tests/test_hf_space.py
@@ -1,0 +1,144 @@
+"""Tests for ``scripts/hf_space.py`` — the shared HF Space deploy helpers."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from hf_space import deploy_pinned_image, filter_prefixed, pin_dockerfile
+from huggingface_hub import SpaceStage
+
+# Verbatim from https://huggingface.co/spaces/extralit/public-demo/raw/main/Dockerfile.
+# Overwriting this with a bare `FROM` line is what silently disabled HF login on previews.
+PUBLIC_DEMO_DOCKERFILE = """\
+FROM extralit/extralit-hf-space:latest
+
+# Copy the auth config section
+COPY .oauth.yaml /home/extralit/
+
+# Uncoment this line to remove the persistence storage warning
+ENV EXTRALIT_SHOW_HUGGINGFACE_SPACE_PERSISTENT_STORAGE_WARNING=false
+"""
+
+DIGEST_PIN = "extralit/extralit-hf-space@sha256:" + "a" * 64
+
+
+def test_filter_prefixed_keeps_only_the_prefix():
+    raw = json.dumps(
+        {
+            "EXTRALIT_DATABASE_URL": "postgres://x",
+            "EXTRALIT_S3_ENDPOINT": "https://s3",
+            "HF_TOKEN": "hf_secret",
+            "DOCKER_USERNAME": "user",
+            "DOCKER_PASSWORD": "pw",
+            "GITHUB_TOKEN": "ghs_secret",
+            "EXTRALITX_FOO": "not-ours",
+        }
+    )
+    assert filter_prefixed(raw, "EXTRALIT_") == {
+        "EXTRALIT_DATABASE_URL": "postgres://x",
+        "EXTRALIT_S3_ENDPOINT": "https://s3",
+    }
+
+
+def test_filter_prefixed_on_malformed_json_returns_empty():
+    assert filter_prefixed("{not json", "EXTRALIT_") == {}
+    assert filter_prefixed("", "EXTRALIT_") == {}
+
+
+def test_pin_dockerfile_preserves_the_rest_of_the_public_demo_dockerfile():
+    out = pin_dockerfile(PUBLIC_DEMO_DOCKERFILE, DIGEST_PIN)
+
+    assert out.splitlines()[0] == f"FROM {DIGEST_PIN}"
+    assert "COPY .oauth.yaml /home/extralit/" in out
+    assert "ENV EXTRALIT_SHOW_HUGGINGFACE_SPACE_PERSISTENT_STORAGE_WARNING=false" in out
+
+
+def test_pin_dockerfile_leaves_no_stray_tag():
+    out = pin_dockerfile("FROM repo/image:v1.2.3\n", DIGEST_PIN)
+
+    assert out == f"FROM {DIGEST_PIN}\n"
+
+
+def test_pin_dockerfile_keeps_the_stage_alias():
+    out = pin_dockerfile("FROM repo/image:latest AS base\nRUN true\n", DIGEST_PIN)
+
+    assert out == f"FROM {DIGEST_PIN} AS base\nRUN true\n"
+
+
+def test_pin_dockerfile_is_idempotent():
+    once = pin_dockerfile(PUBLIC_DEMO_DOCKERFILE, DIGEST_PIN)
+
+    assert pin_dockerfile(once, DIGEST_PIN) == once
+
+
+def test_pin_dockerfile_on_an_already_pinned_file_changes_nothing():
+    pinned = pin_dockerfile(PUBLIC_DEMO_DOCKERFILE, DIGEST_PIN)
+
+    assert pin_dockerfile(pinned, DIGEST_PIN) == pinned
+
+
+def test_pin_dockerfile_without_a_from_line_raises():
+    with pytest.raises(ValueError):
+        pin_dockerfile("# no FROM here\nRUN true\n", DIGEST_PIN)
+
+
+class FakeRuntime:
+    def __init__(self, stage):
+        self.stage = stage
+
+
+class FakeApi:
+    """Records calls so the skip branch can be asserted without mocking libraries."""
+
+    def __init__(self, tmp_path, dockerfile):
+        self._path = tmp_path / "Dockerfile"
+        self._path.write_text(dockerfile)
+        self.uploads = []
+        self.waits = 0
+
+    def hf_hub_download(self, repo_id, filename, repo_type=None):
+        return str(self._path)
+
+    def upload_file(self, *, path_or_fileobj, path_in_repo, repo_id, repo_type, commit_message):
+        self.uploads.append(path_or_fileobj.decode())
+        self._path.write_text(path_or_fileobj.decode())
+
+    def get_space_runtime(self, repo_id):
+        return FakeRuntime(SpaceStage.RUNNING)
+
+    def wait_for_space(self, repo_id, timeout=None, poll_interval=None):
+        self.waits += 1
+        return FakeRuntime(SpaceStage.RUNNING)
+
+
+def test_deploy_pinned_image_skips_upload_and_wait_when_already_pinned(tmp_path):
+    already = pin_dockerfile(PUBLIC_DEMO_DOCKERFILE, DIGEST_PIN)
+    api = FakeApi(tmp_path, already)
+
+    runtime = deploy_pinned_image(api, "extralit/public-demo", DIGEST_PIN)
+
+    assert api.uploads == []
+    assert api.waits == 0
+    assert runtime.stage == SpaceStage.RUNNING
+
+
+def test_deploy_pinned_image_uploads_and_waits_when_the_digest_changed(tmp_path, monkeypatch):
+    monkeypatch.setattr("hf_space.time.sleep", lambda _seconds: None)
+    api = FakeApi(tmp_path, PUBLIC_DEMO_DOCKERFILE)
+
+    deploy_pinned_image(api, "extralit/public-demo", DIGEST_PIN)
+
+    assert len(api.uploads) == 1
+    assert api.uploads[0].startswith(f"FROM {DIGEST_PIN}\n")
+    assert "COPY .oauth.yaml /home/extralit/" in api.uploads[0]
+    assert api.waits == 1
+
+
+def test_deploy_pinned_image_raises_when_the_space_does_not_settle_running(tmp_path, monkeypatch):
+    monkeypatch.setattr("hf_space.time.sleep", lambda _seconds: None)
+    api = FakeApi(tmp_path, PUBLIC_DEMO_DOCKERFILE)
+    api.wait_for_space = lambda repo_id, timeout=None, poll_interval=None: FakeRuntime(SpaceStage.BUILD_ERROR)
+
+    with pytest.raises(RuntimeError):
+        deploy_pinned_image(api, "extralit/public-demo", DIGEST_PIN)

--- a/tests/test_hf_space.py
+++ b/tests/test_hf_space.py
@@ -89,12 +89,19 @@ class FakeRuntime:
 
 
 class FakeApi:
-    """Records calls so the skip branch can be asserted without mocking libraries."""
+    """Records calls so the branch taken can be asserted without mocking libraries.
 
-    def __init__(self, tmp_path, dockerfile):
+    ``stages`` is consumed one entry per ``get_space_runtime`` poll, the last one repeating,
+    which is what lets a test replay "the Hub still reports the pre-commit stage".
+    """
+
+    def __init__(self, tmp_path, dockerfile, stages=(SpaceStage.RUNNING,), settled=SpaceStage.RUNNING):
         self._path = tmp_path / "Dockerfile"
         self._path.write_text(dockerfile)
+        self._stages = list(stages)
+        self._settled = settled
         self.uploads = []
+        self.polls = 0
         self.waits = 0
 
     def hf_hub_download(self, repo_id, filename, repo_type=None):
@@ -105,11 +112,17 @@ class FakeApi:
         self._path.write_text(path_or_fileobj.decode())
 
     def get_space_runtime(self, repo_id):
-        return FakeRuntime(SpaceStage.RUNNING)
+        self.polls += 1
+        return FakeRuntime(self._stages.pop(0) if len(self._stages) > 1 else self._stages[0])
 
     def wait_for_space(self, repo_id, timeout=None, poll_interval=None):
         self.waits += 1
-        return FakeRuntime(SpaceStage.RUNNING)
+        return FakeRuntime(self._settled)
+
+
+@pytest.fixture
+def instant_sleep(monkeypatch):
+    monkeypatch.setattr("hf_space.time.sleep", lambda _seconds: None)
 
 
 def test_deploy_pinned_image_skips_upload_and_wait_when_already_pinned(tmp_path):
@@ -123,9 +136,20 @@ def test_deploy_pinned_image_skips_upload_and_wait_when_already_pinned(tmp_path)
     assert runtime.stage == SpaceStage.RUNNING
 
 
-def test_deploy_pinned_image_uploads_and_waits_when_the_digest_changed(tmp_path, monkeypatch):
-    monkeypatch.setattr("hf_space.time.sleep", lambda _seconds: None)
-    api = FakeApi(tmp_path, PUBLIC_DEMO_DOCKERFILE)
+def test_deploy_pinned_image_waits_when_already_pinned_but_still_building(tmp_path):
+    # The create path: the rendered template pinned the digest, so the commit that triggered
+    # the build was the template upload, not this one. Reporting mid-build would be a lie.
+    already = pin_dockerfile(PUBLIC_DEMO_DOCKERFILE, DIGEST_PIN)
+    api = FakeApi(tmp_path, already, stages=(SpaceStage.BUILDING,))
+
+    deploy_pinned_image(api, "extralit-dev/pr-42", DIGEST_PIN)
+
+    assert api.uploads == []
+    assert api.waits == 1
+
+
+def test_deploy_pinned_image_uploads_and_waits_when_the_digest_changed(tmp_path, instant_sleep):
+    api = FakeApi(tmp_path, PUBLIC_DEMO_DOCKERFILE, stages=(SpaceStage.BUILDING,))
 
     deploy_pinned_image(api, "extralit/public-demo", DIGEST_PIN)
 
@@ -135,10 +159,48 @@ def test_deploy_pinned_image_uploads_and_waits_when_the_digest_changed(tmp_path,
     assert api.waits == 1
 
 
-def test_deploy_pinned_image_raises_when_the_space_does_not_settle_running(tmp_path, monkeypatch):
-    monkeypatch.setattr("hf_space.time.sleep", lambda _seconds: None)
-    api = FakeApi(tmp_path, PUBLIC_DEMO_DOCKERFILE)
-    api.wait_for_space = lambda repo_id, timeout=None, poll_interval=None: FakeRuntime(SpaceStage.BUILD_ERROR)
+def test_deploy_pinned_image_does_not_accept_the_stage_from_before_the_commit(tmp_path, instant_sleep):
+    # The Hub reports the pre-commit RUNNING for two polls before scheduling the build. Waiting
+    # straight away would return that stale RUNNING and green-light the previous image.
+    api = FakeApi(
+        tmp_path,
+        PUBLIC_DEMO_DOCKERFILE,
+        stages=(SpaceStage.RUNNING, SpaceStage.RUNNING, SpaceStage.BUILDING),
+    )
 
-    with pytest.raises(RuntimeError):
+    deploy_pinned_image(api, "extralit/public-demo", DIGEST_PIN)
+
+    assert api.polls == 3
+    assert api.waits == 1
+
+
+def test_deploy_pinned_image_raises_when_the_rebuild_never_starts(tmp_path, instant_sleep):
+    api = FakeApi(tmp_path, PUBLIC_DEMO_DOCKERFILE, stages=(SpaceStage.RUNNING,))
+
+    with pytest.raises(RuntimeError, match="never started building"):
         deploy_pinned_image(api, "extralit/public-demo", DIGEST_PIN)
+
+    assert api.waits == 0
+
+
+def test_deploy_pinned_image_raises_when_the_space_does_not_settle_running(tmp_path, instant_sleep):
+    api = FakeApi(
+        tmp_path,
+        PUBLIC_DEMO_DOCKERFILE,
+        stages=(SpaceStage.BUILDING,),
+        settled=SpaceStage.BUILD_ERROR,
+    )
+
+    with pytest.raises(RuntimeError, match="settled in"):
+        deploy_pinned_image(api, "extralit/public-demo", DIGEST_PIN)
+
+
+def test_deploy_pinned_image_accepts_a_space_that_built_then_went_to_sleep(tmp_path, instant_sleep):
+    # SLEEPING is absent from SpaceStage in huggingface_hub 1.26.0, so it arrives as a bare
+    # string; extralit-dev/develop sits in it between deploys. It is a built Space, not a
+    # failed one, and rejecting it would fail the deploy that just succeeded.
+    api = FakeApi(tmp_path, PUBLIC_DEMO_DOCKERFILE, stages=(SpaceStage.BUILDING,), settled="SLEEPING")
+
+    runtime = deploy_pinned_image(api, "extralit-dev/develop", DIGEST_PIN)
+
+    assert runtime.stage == "SLEEPING"

--- a/tests/test_space_template.py
+++ b/tests/test_space_template.py
@@ -31,18 +31,18 @@ def test_render_leaves_dockerfile_arg_syntax_alone():
 
 
 def test_manifest_declares_every_placeholder_used_by_the_template():
-    manifest = json.loads((TEMPLATE_DIR / "manifest.json").read_text())
+    manifest = json.loads((TEMPLATE_DIR / "manifest.json").read_text(encoding="utf-8"))
     declared = set(manifest["variables"])
 
     used = set()
     for name in manifest["files"]:
-        used |= set(_placeholders((TEMPLATE_DIR / name).read_text()))
+        used |= set(_placeholders((TEMPLATE_DIR / name).read_text(encoding="utf-8")))
 
     assert used == declared
 
 
 def test_manifest_carries_no_required_secrets():
-    manifest = json.loads((TEMPLATE_DIR / "manifest.json").read_text())
+    manifest = json.loads((TEMPLATE_DIR / "manifest.json").read_text(encoding="utf-8"))
 
     # That contract lives in the Hub's `deployment_templates.required_secrets`. A second
     # copy here has no seeder, and the drift shows up as a Space missing a secret.
@@ -93,5 +93,5 @@ def test_rendered_readme_frontmatter_is_valid_yaml():
 def test_unrendered_template_is_itself_parseable_yaml():
     # `__VAR__` is a plain scalar; `{{VAR}}` would be a flow mapping and fail pre-commit's
     # check-yaml, which runs with no path filters.
-    yaml.safe_load((TEMPLATE_DIR / ".oauth.yaml").read_text())
-    yaml.safe_load((TEMPLATE_DIR / "README.md").read_text().split("---")[1])
+    yaml.safe_load((TEMPLATE_DIR / ".oauth.yaml").read_text(encoding="utf-8"))
+    yaml.safe_load((TEMPLATE_DIR / "README.md").read_text(encoding="utf-8").split("---")[1])

--- a/tests/test_space_template.py
+++ b/tests/test_space_template.py
@@ -1,0 +1,97 @@
+"""Tests for the ``space_template/`` renderer and the committed template itself."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from hf_space import render, render_space_files, workspaces_value
+
+TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "space_template"
+
+
+def test_render_substitutes_placeholders():
+    assert render("FROM __IMAGE_REF__\n", {"IMAGE_REF": "repo@sha256:abc"}) == "FROM repo@sha256:abc\n"
+
+
+def test_render_substitutes_every_occurrence():
+    assert render("__A__/__A__", {"A": "x"}) == "x/x"
+
+
+def test_render_rejects_a_placeholder_it_was_not_given():
+    # Silent pass-through is the exact failure mode that wipes a Space's config.
+    with pytest.raises(KeyError):
+        render("title: __TITLE__\nlicense: __LICENSE__\n", {"TITLE": "Extralit"})
+
+
+def test_render_leaves_dockerfile_arg_syntax_alone():
+    assert render("ENV X=${HOME}\n", {}) == "ENV X=${HOME}\n"
+
+
+def test_manifest_declares_every_placeholder_used_by_the_template():
+    manifest = json.loads((TEMPLATE_DIR / "manifest.json").read_text())
+    declared = set(manifest["variables"])
+
+    used = set()
+    for name in manifest["files"]:
+        used |= set(_placeholders((TEMPLATE_DIR / name).read_text()))
+
+    assert used == declared
+
+
+def test_manifest_carries_no_required_secrets():
+    manifest = json.loads((TEMPLATE_DIR / "manifest.json").read_text())
+
+    # That contract lives in the Hub's `deployment_templates.required_secrets`. A second
+    # copy here has no seeder, and the drift shows up as a Space missing a secret.
+    assert "required_secrets" not in manifest
+
+
+def _placeholders(text: str) -> list[str]:
+    import re
+
+    return re.findall(r"__([A-Z0-9_]+)__", text)
+
+
+def test_rendered_template_has_no_placeholders_left():
+    files = render_space_files(TEMPLATE_DIR, {"IMAGE_REF": "extralit/extralit-hf-space@sha256:abc"})
+
+    for name, text in files.items():
+        assert not _placeholders(text), f"{name} still has placeholders"
+
+
+def test_rendered_dockerfile_copies_the_oauth_config():
+    files = render_space_files(TEMPLATE_DIR, {"IMAGE_REF": "repo@sha256:abc"})
+
+    assert files["Dockerfile"].splitlines()[0] == "FROM repo@sha256:abc"
+    assert "COPY .oauth.yaml /home/extralit/" in files["Dockerfile"]
+
+
+def test_rendered_oauth_config_is_valid_yaml_with_the_requested_workspaces():
+    files = render_space_files(
+        TEMPLATE_DIR, {"IMAGE_REF": "r@sha256:a", "WORKSPACES": workspaces_value(["public", "test"])}
+    )
+
+    parsed = yaml.safe_load(files[".oauth.yaml"])
+    assert parsed["enabled"] is True
+    assert parsed["providers"] == [{"name": "huggingface"}]
+    assert parsed["allowed_workspaces"] == [{"name": "public"}, {"name": "test"}]
+
+
+def test_rendered_readme_frontmatter_is_valid_yaml():
+    files = render_space_files(TEMPLATE_DIR, {"IMAGE_REF": "r@sha256:a", "TITLE": "Extralit PR Preview"})
+
+    front = yaml.safe_load(files["README.md"].split("---")[1])
+    assert front["title"] == "Extralit PR Preview"
+    assert front["sdk"] == "docker"
+    assert front["app_port"] == 6900
+    assert front["hf_oauth"] is True
+
+
+def test_unrendered_template_is_itself_parseable_yaml():
+    # `__VAR__` is a plain scalar; `{{VAR}}` would be a flow mapping and fail pre-commit's
+    # check-yaml, which runs with no path filters.
+    yaml.safe_load((TEMPLATE_DIR / ".oauth.yaml").read_text())
+    yaml.safe_load((TEMPLATE_DIR / "README.md").read_text().split("---")[1])

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,726 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "arrow"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "croniter"
+version = "6.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/57/2e2a65aee2a70483cb28e2b7e15a072d00a523207593b44400d4717bb100/croniter-6.2.4.tar.gz", hash = "sha256:fc124f751b1b04805c2a04b061898b436b45ab2320b045e1e052ea895de65189", size = 166267, upload-time = "2026-07-10T09:52:59.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/ba/d678e5bd329646ca51d3c92addbc77804e86d21f4b6b6a027218e6abb010/croniter-6.2.4-py3-none-any.whl", hash = "sha256:8ef3d544107a5c05a150a2d78f8bf5a8eb9c5c4d93405a736b824109574e3f4d", size = 46677, upload-time = "2026-07-10T09:52:58.425Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "extralit-hf-space"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "honcho" },
+    { name = "httpx" },
+    { name = "pymupdf4llm" },
+    { name = "redis" },
+    { name = "rq" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "huggingface-hub" },
+    { name = "pytest" },
+    { name = "rq-dashboard" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "honcho", specifier = "~=2.0.0" },
+    { name = "httpx" },
+    { name = "pymupdf4llm", specifier = "~=0.0.27" },
+    { name = "redis" },
+    { name = "rq" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "huggingface-hub", specifier = "==1.26.0" },
+    { name = "pytest" },
+    { name = "rq-dashboard" },
+    { name = "ruff" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/57/3ba6e6cb097f85b855b00163d169f35365f44277df044dcf96d55b8f62a3/filelock-3.32.2.tar.gz", hash = "sha256:c33351e1f49cae33414acbc6d56784e6ecee82514ec90795da1161fc4836b5b8", size = 217172, upload-time = "2026-07-29T22:46:04.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/e8/72f8cef9fdfeffe06213fe8508039396ee48daa0e3259457ed766173bfd6/filelock-3.32.2-py3-none-any.whl", hash = "sha256:87dd94cf281e586d135fa51132b8e3d9a598b316e90377a288663c9321036c82", size = 98830, upload-time = "2026-07-29T22:46:03.52Z" },
+]
+
+[[package]]
+name = "flask"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/62/3c062f593bd92ef4e77a0ef39541e3d82a0a1d3947c8a777a02a13a27828/hf_xet-1.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:70cbb9c896901600128cb9b6f06e132954fbede1db30f31f7c6c63f84cb7c31d", size = 4074584, upload-time = "2026-08-03T22:32:47.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1e/c0ad437dd267a8e435bef594acf781bbc3874ff0b6435b4962d03ecf7cc4/hf_xet-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23379c2f9ec8696d952b16414a2bae72cad86a52df869b050698ba60f538c675", size = 3867381, upload-time = "2026-08-03T22:32:49.049Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ee/7c0d7b6ab336167531b1c30af2af003f054af4c749becbd7209ae33a77c3/hf_xet-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2f7278c05c22fd60cb436cda1269649b3e81db65ecdc8496e5e164aa4143e7b", size = 4453982, upload-time = "2026-08-03T22:32:50.568Z" },
+    { url = "https://files.pythonhosted.org/packages/63/06/ad8eab1c9525246650cbaa821caa3cdbaca734ab1a5b8c91bea09cbd8d69/hf_xet-1.6.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:948f15d3a9545cfe5932f6bd8b440f6ae630aee108f14b7bd6c561f7c2dcc522", size = 4249445, upload-time = "2026-08-03T22:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/26/1eee8aedb0dafc1ab9717dc9ac602cde33361b232dc06803f1f6ed18b58c/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5153e6bb103ad49d6ea9f1b2e230db5a2ea32551ad09a706d2f61d7c7c80d80e", size = 4451099, upload-time = "2026-08-03T22:32:54.114Z" },
+    { url = "https://files.pythonhosted.org/packages/67/57/0b88af1f194ab6c9c650547d9cc06bfeaab836ae4dcdb331676bfb8be95a/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:35cec30d75c6f9eb9c16a77cef68e85a103b72e24d4b473714ec9ff06428bab9", size = 4664712, upload-time = "2026-08-03T22:32:55.547Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a0/26b717a9d1840e8abf48dcec64b5ed8fbe472671d38ad28d30e147132b33/hf_xet-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5789835d7c6bc9436962853192082374297fb72d7eff7e7762ec25ceb7e25338", size = 4025906, upload-time = "2026-08-03T22:32:57.391Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f6/4a9966633c6fef83af997e2cff68ec1963676d412bdfd096df2a93b8e185/hf_xet-1.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:75765820ce4700db3750c94acc8fe27c5fae4c9ec000a0dbac3ca082acf97765", size = 3849221, upload-time = "2026-08-03T22:32:59.123Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
+]
+
+[[package]]
+name = "honcho"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/c8/d860888358bf5c8a6e7d78d1b508b59b0e255afd5655f243b8f65166dafd/honcho-2.0.0.tar.gz", hash = "sha256:af3815c03c634bf67d50f114253ea9fef72ecff26e4fd06b29234789ac5b8b2e", size = 45618, upload-time = "2024-10-06T14:26:53.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/1c/25631fc359955569e63f5446dbb7022c320edf9846cbe892ee5113433a7e/honcho-2.0.0-py3-none-any.whl", hash = "sha256:56dcd04fc72d362a4befb9303b1a1a812cba5da283526fbc6509be122918ddf3", size = 22093, upload-time = "2024-10-06T14:26:52.181Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/db/3582597f8be0d34bd6881365a26d390854f12893eabdd62dd36de9df5a47/huggingface_hub-1.26.0.tar.gz", hash = "sha256:c8cd4e2df1ba9402f77fce9b509ec1d52debb502551789473f34016acc14e361", size = 936665, upload-time = "2026-07-30T14:12:04.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/bb/63a644c75b545f3ff394b822e9bd1c4a9586489c618b77a4d8a44a33a23b/huggingface_hub-1.26.0-py3-none-any.whl", hash = "sha256:e8cca670caa5d8dfa7e45bf45e86b466698198cd8150c021bcdb4a86b9252364", size = 780357, upload-time = "2026-07-30T14:12:01.998Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.28.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/fb/b6761fa2d5266f2cdb24c3b91f4023070ab7848381417678e7a289a1d52a/pymupdf-1.28.2.tar.gz", hash = "sha256:5e0be7908a715aa20333caddd73f1d6f01e4cd0c26e869fa2dd0b7f344da2249", size = 87903557, upload-time = "2026-08-06T21:43:23.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/51/550c9a75c4ff3245cb4ecb7bb95cbe2ab7374230b8e2b7a1f7259444150b/pymupdf-1.28.2-cp310-abi3-macosx_10_15_x86_64.whl", hash = "sha256:5fc315b425ff1f7afdd1ea2f348205cb19b806767daae7ce4d64115799c2bae1", size = 24645079, upload-time = "2026-08-06T21:37:25.001Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/3591f781b417b382a8487a2356e927acfe858b1043bab0ec47f6805bb109/pymupdf-1.28.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:7113846b35dbf0a033f088e4f4fb543dabeb4b0b12c112966a1ca1ee2d5eacae", size = 23875605, upload-time = "2026-08-06T21:37:40.369Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/86/4a68f080b71b46802178346af46486e1697508e760855ff5f3b218a6dff7/pymupdf-1.28.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:3050a233dde1211efe89ada74e2add6238436434159f46097a1423aad2842545", size = 25095554, upload-time = "2026-08-06T21:37:58.485Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/06/dace3e27af26690cb20bead80dbac42941b0841eb689b8aabbd67dde16f0/pymupdf-1.28.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:397d6715c1f0df7548a92d0afd8ce370fc48fa47aeefac16be2bc04a16a8227f", size = 25762500, upload-time = "2026-08-06T21:38:17.438Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/61/4146dfa1d8172a1ce8d59f0eed94896ddefb8deb2274534d0522fbb8abf5/pymupdf-1.28.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f89fb2d86d07d643a269f17a093105057e20c79c1d06c103b53600067b6d2b01", size = 25986309, upload-time = "2026-08-06T21:38:35.472Z" },
+    { url = "https://files.pythonhosted.org/packages/52/60/1fb6e64676f7500ebe89054b9e5bbbe14d3101c92d5f1a40ac9a35227673/pymupdf-1.28.2-cp310-abi3-win32.whl", hash = "sha256:530ef543a3885b3b81cb72a854e7c5a625a9233201221132bb6c31698c6a2bdb", size = 18525353, upload-time = "2026-08-06T21:38:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/61/d563bbccba262f9dd6d2d35ccb72593648184d886188efb12d9ce8f34dd6/pymupdf-1.28.2-cp310-abi3-win_amd64.whl", hash = "sha256:ebd244918798502d7b4504c90410d1711a4d7675a32584ca30f1bab419ecbffe", size = 19826532, upload-time = "2026-08-06T21:39:00.213Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/93/08f404a1f0155fe24137cf2d3aabd3e2b4b08c62053ed89c60f2611be3e9/pymupdf-1.28.2-cp310-abi3-win_arm64.whl", hash = "sha256:ffe91a24edc75c80da2a4b62f50fc0f54632d34fc8fe4cbc48e5c7ff07cf8fb4", size = 19759252, upload-time = "2026-08-06T21:39:12.937Z" },
+    { url = "https://files.pythonhosted.org/packages/58/8c/d897dcd32a25b58186c968b15ce4324ca029e9d96460de12325314e390be/pymupdf-1.28.2-cp313-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:2e1b574c0fd2cb238021033fd3c0f9c4388816638df064e4bfb56d9d81736dc8", size = 18399403, upload-time = "2026-08-06T21:39:25.008Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f1/de34a1c53fe2bf8c6e71db84b0ced782d408970c9810d2b456a2ae96814c/pymupdf-1.28.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:fd481ed48bef56305c41fb7e05a055c03345c899c7b101dad086258b438f8168", size = 25802333, upload-time = "2026-08-06T21:39:41.426Z" },
+]
+
+[[package]]
+name = "pymupdf4llm"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pymupdf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/03/99/2634b56ff2b68558e742c6e10cd798ed3b5b5af6cc659454b9f37e7b4ecf/pymupdf4llm-0.0.27.tar.gz", hash = "sha256:35cc8bd6e0968bc1300b1fe4500f52e47da6b570af19af6c193e5fb6ee367008", size = 29368, upload-time = "2025-07-19T11:52:01.059Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/c8/7eed2e902b61574b15b295017ddb5738c4970aa9ab76903fbaace28a522e/pymupdf4llm-0.0.27-py3-none-any.whl", hash = "sha256:2eaaf9419c35520efda38f3806a276f2ec6cd29564fbb60a5c9c53a49fedb13c", size = 30055, upload-time = "2025-07-19T11:52:04.089Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "redis"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/99/604f0b666d4c616d891cf77ebb9db6bb21601344c051aebf1b72b9ff915f/redis-8.1.0.tar.gz", hash = "sha256:6e1a19beef9225c83efd689c7e6b7da2d5215b1f42cd13b7fc3714d0a09c7b25", size = 5254356, upload-time = "2026-07-30T08:51:00.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/9d/c5731f6e3608663d4d3656fd8d3aecee8b509c3082818f5a13eae925baea/redis-8.1.0-py3-none-any.whl", hash = "sha256:a4fe1aac3d3b3cc791d4b3d5931c5a956045dc951ee74d1c913ee3ac4d2ee9fb", size = 560618, upload-time = "2026-07-30T08:50:58.497Z" },
+]
+
+[[package]]
+name = "redis-sentinel-url"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/e3/68de4c8aacbd9952667d7d0f5af55b873553a09a6227ac5b7f7c622610c9/Redis-Sentinel-Url-1.0.1.tar.gz", hash = "sha256:ec1854ab9379a28789423c3cd4082739fb69c7b4b11bb50ae7858697c131b13e", size = 7599, upload-time = "2017-04-05T07:47:55.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/35/20f997f367c87ef1e6ebf418af7c2450cb5da860d066d7229226031534ad/Redis_Sentinel_Url-1.0.1-py2.py3-none-any.whl", hash = "sha256:c6991e2000c5c7a5e2b95eb2d62fd5b0a6b02a59554caf0f9f79d18e152d9663", size = 4685, upload-time = "2017-04-05T07:47:53.545Z" },
+]
+
+[[package]]
+name = "rq"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "croniter" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/a8/7bf65cda593feb5888214a4d1e64aae6fc5eb0bbbb74df922c916099a3e5/rq-2.10.0.tar.gz", hash = "sha256:2d8c533dd27500fedabec06295f18db595966e4f22744e6988fe31155b8f7a21", size = 754610, upload-time = "2026-06-20T03:11:45.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/d3/f8c59750a1c98f99d225954eb2c3dd89f2d66b666c448b4b0dff79ab29ed/rq-2.10.0-py3-none-any.whl", hash = "sha256:1f072e0ff79771f3d3a810170df4c4836dca9ce9f31330a9fc25e25277620ec8", size = 124665, upload-time = "2026-06-20T03:11:47.524Z" },
+]
+
+[[package]]
+name = "rq-dashboard"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+    { name = "flask" },
+    { name = "redis" },
+    { name = "redis-sentinel-url" },
+    { name = "rq" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/46/f5bae00d7b29a90bd88158b25757c3624073e0e766c0d82bc1325a827a7f/rq_dashboard-0.9.0.tar.gz", hash = "sha256:33472117abe47b793d608e60fff5d29ed84e8e5a2c13c793ea3dbfdbde52dfb6", size = 214248, upload-time = "2026-07-02T08:02:20.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/83/2f399fa789778dc8f3f4b5e74c23b06d736135e3cb93c1369b88dc431468/rq_dashboard-0.9.0-py2.py3-none-any.whl", hash = "sha256:bcb670a097b1539d1cfe752a1609e3870177b253c4ef49e037d518eef2cd8b86", size = 217225, upload-time = "2026-07-02T08:02:18.879Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/e1/4508a569211b35599016e84ba65c1a992b7a4004b4b6c4bea02a851cba1b/ruff-0.16.2.tar.gz", hash = "sha256:c3d7828d12e8927a6fc65fe38e2c2541b9e762d360a1786d752cb1b8883b3c9c", size = 4885811, upload-time = "2026-08-07T13:31:01.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/57/db19951540f98859c956b50bdb4d31089b4d91e9f15e2968e7d5193806d5/ruff-0.16.2-py3-none-linux_armv6l.whl", hash = "sha256:3c8de4cf2181f01d57946d87d777aa52916976fc09942aed89938fab5e013318", size = 10847925, upload-time = "2026-08-07T13:30:14.468Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/995fe85a8470d3e391ac0f7fa8054bb454eaf33ee138196d6172ed1079c0/ruff-0.16.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a48cc05c6fbc811ca81b5d7ba95375affea6582d1b8024e455e41afbbf55344", size = 11072662, upload-time = "2026-08-07T13:30:18.143Z" },
+    { url = "https://files.pythonhosted.org/packages/32/53/370d767c61c71a971a4ace36703a7ecd8c393956349a7325d7fab2b56827/ruff-0.16.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2c0d14fcbb26c91f0f867a6dc9bd71bbc30b1b6151829c884f23faeab2e5700", size = 10566771, upload-time = "2026-08-07T13:30:20.899Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d6/9d96948caf5a632be62d62202d5ec914d6856f204fd79eb036e5915e79ea/ruff-0.16.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe", size = 10975825, upload-time = "2026-08-07T13:30:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/92/ea87129b3414acb0b5770563779c51804d37ac67675c7ba35447ddb14773/ruff-0.16.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f", size = 10649437, upload-time = "2026-08-07T13:30:26.097Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/43/f8f291dcd4af5bb7872b74fdfa41a7cd7c856ca1d4069670971cf1b9f5cb/ruff-0.16.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7e36fbfba65510548156902bcf1350a979a958ce0347ce0f90d73894036b39f", size = 11446761, upload-time = "2026-08-07T13:30:28.752Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4a/ef991fb2fcf516ab71f0808adcdd8da5e18c8cde447f4ceaf5f47a5132a5/ruff-0.16.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0eab35f80df8f134aae5d1630e751901321d317cc8e50dc39e36fa3ed34cd12", size = 12336364, upload-time = "2026-08-07T13:30:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/24/f615e74f307e6ca0e56a482872477b856c70d530aa356abfb6dfe5ca8a80/ruff-0.16.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ea8c0594feb894e89c8c61ab9c103d38b0ea72dfde6c594107147ca31b1140", size = 11630720, upload-time = "2026-08-07T13:30:34.426Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d3/8ef50149e8412a77f7ab409efdef0e2b23803707a3863da4fc64cb23d459/ruff-0.16.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab3d62dde0b19facdd632008cc4827fc28ada7736c6bd35ab6f1050f0bfed53f", size = 11466130, upload-time = "2026-08-07T13:30:36.958Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a7/a19334985c4dea8c381981fa252cd854c7ee52dc4b1686dc16f4a911c702/ruff-0.16.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e43e1f5b8388da9eca1b9e88328d47a5cec794633ccf6f7484ac2dd15eee92c0", size = 11523634, upload-time = "2026-08-07T13:30:39.822Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6c/96d192b0e742412ceda08c0a50f9669b253dde9fd6a60ea1a10c9fa79a63/ruff-0.16.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c24788a980581e1d7ea3a0cbe4344c4fbeb0a6a9b1f4713aa46bb104f8294690", size = 10949807, upload-time = "2026-08-07T13:30:42.745Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/51/e26599ceca11e79ee255c7df515995561edf87e9ca1893284e44d98f5a86/ruff-0.16.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:81806b08329130005dd4a8a8394a0c9da8c6f4cafb16ba438d2a2ee6a18bedf1", size = 10646891, upload-time = "2026-08-07T13:30:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/68/01/800c4b1f97bc8d7c6029e06b1f20473a3cf1e13c4933d8f3342add83fc55/ruff-0.16.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4ce4e02bad779bef557f541a1b31f20d6abeae1cc05ed1b1ac019d4ffd1044c8", size = 11162063, upload-time = "2026-08-07T13:30:48.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/1477ea50fc5a0d4b0b71d1d63d50770bdd794d90b43e37a7618e63ec9894/ruff-0.16.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e0422abdf70070255fc4073ce9dfc814cc03db577013761ddd09bc1e4a9a4fbd", size = 11556038, upload-time = "2026-08-07T13:30:50.686Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/76/a7776f32048d991e16d4fa8ff91790b877342d3596cc3ed04acdbf1aaedc/ruff-0.16.2-py3-none-win32.whl", hash = "sha256:bf3a63d78fb39f4bf5ac8ae52051c5520505301abe19ba4e204c453b3f09bb0b", size = 10872850, upload-time = "2026-08-07T13:30:53.471Z" },
+    { url = "https://files.pythonhosted.org/packages/00/0d/929c800d920e61397d82a01b60bffc68da3052c17d31de59efaad2e4ed75/ruff-0.16.2-py3-none-win_amd64.whl", hash = "sha256:bcabe2f6d0fc7819f1431793005af4e4de7371927d037345bf941252b195b9fa", size = 12023338, upload-time = "2026-08-07T13:30:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/93e26c22c5f78ff87363e07da49c84955affbeb1098bd1936bf3b3f293bf/ruff-0.16.2-py3-none-win_arm64.whl", hash = "sha256:d614e95cedf38a2053fd351c55b103ba30d017d61688fdbfd40ee0412852a99f", size = 11374065, upload-time = "2026-08-07T13:30:58.775Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]

--- a/uv.lock
+++ b/uv.lock
@@ -117,6 +117,7 @@ dependencies = [
 dev = [
     { name = "huggingface-hub" },
     { name = "pytest" },
+    { name = "pyyaml" },
     { name = "rq-dashboard" },
     { name = "ruff" },
 ]
@@ -134,6 +135,7 @@ requires-dist = [
 dev = [
     { name = "huggingface-hub", specifier = "==1.26.0" },
     { name = "pytest" },
+    { name = "pyyaml" },
     { name = "rq-dashboard" },
     { name = "ruff" },
 ]


### PR DESCRIPTION
Follow-up to #8. The keyless `deploy-space` job merged there **fails in practice** — caught by the staging smoke test ([run 31247598490](https://github.com/Extralit/extralit-hf-space/actions/runs/31247598490)).

## What the smoke test proved

`restart_space()` returned **401** against `extralit-dev/develop`.

Crucially it was *not* an `OIDCError`. `HF_OIDC_RESOURCE` was set and `get_token()` raises rather than falling back, so the traceback landing inside `restart_space` proves a valid OIDC token had already been minted. Two conclusions:

- The trusted publisher on `extralit-dev/develop` **is** registered and its claims match — a bad publisher fails earlier, as `invalid_grant`.
- **A repo-scoped OIDC token cannot restart a Space.** A repo publisher grants *write access to that one repo*; restarting is a runtime operation, not a repo write.

## The fix

Deploy the way [HF's own GitHub Actions docs](https://huggingface.co/docs/hub/en/spaces-github-actions) do — by writing to the Space repo, which is exactly what the credential grants. `deploy-space` now rewrites the Space `Dockerfile`'s `FROM` line to the digest `build` just pushed and commits it; HF rebuilds on the new commit.

`build` gains an `image_digest` output for this. `deploy-pr-space` is untouched and still needs its `HF_TOKEN` (Trusted Publishers cannot create repos).

## This also retires `factory_reboot`

The v0.7.0 stale-base bug (green job, Space still serving 0.6.1) was only possible because the `FROM` line was a moving **tag**, so HF reused the base image it had already built. `factory_reboot=True` was a workaround for that. A digest cannot resolve to a previously-built image, so the failure mode is gone at the root rather than suppressed.

## Verification

Exercised the rewrite against both **live** Space Dockerfiles:

- only line 1 changes; the remaining lines are byte-identical (the `COPY .oauth.yaml` / `ENV` lines are preserved)
- idempotent — re-running with the same digest is a no-op
- a Dockerfile with no `FROM` line fails loudly instead of silently no-opping

A no-change commit would trigger no rebuild, so that path skips the wait and instead asserts the Space's *current* stage is `RUNNING` — a previously-failed build cannot be reported as a green redeploy.

**Still unverified until this merges and staging is dispatched:** that the OIDC token can write to the Space repo. It is the documented purpose of a repo publisher, but #8 is a reminder that documented-adjacent is not observed. `main` is the smoke test — the publisher pins `branch=main`, so this cannot be tested from the PR branch.

Docs updated in `CLAUDE.md`; the monorepo counterpart is Extralit/extralit#238.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deployment**
  * Hugging Face Space deployments now use exact image versions and verify successful rebuilds.
  * Avoids unnecessary updates when the deployed image is unchanged.
  * Added consistent OAuth, workspace, metadata, and display configuration for new Spaces.

* **Monitoring**
  * Added automated checks for configuration drift in existing Spaces.

* **Documentation**
  * Updated deployment, authentication, and workflow guidance.

* **Tests**
  * Added coverage for deployments, templates, OAuth setup, rebuild handling, and configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->