### PR TITLE
ci: lint GitHub Actions workflows with actionlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,8 @@ repos:
       - id: ruff
         args: [--fix]
       - id: ruff-format
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.9
+    hooks:
+      - id: actionlint


### PR DESCRIPTION
Adds `actionlint` to pre-commit. Companion to Extralit/extralit#239, which wires the same hook into the monorepo.

```yaml
- repo: https://github.com/rhysd/actionlint
  rev: v1.7.9
  hooks:
    - id: actionlint
```

Uses the `golang` variant rather than `actionlint-docker` / `actionlint-system`: pre-commit 4.x provisions the Go toolchain itself, so contributors need nothing installed. The hook ships its own `files: ^\.github/workflows/` scope, so it only fires when a workflow file is staged.

The dispatch-driven workflows here matter more than most — `build-hf-space.yml` alone carries the `resolve-env` payload mapping, the `id-token: write` grant that must stay on `deploy-space`, and the `ALL_SECRETS` allowlist. A typo'd `steps.*` reference in any of them resolves to empty rather than failing, which is exactly the silent-wrong-result class this repo already guards against elsewhere.

## Verification

`pre-commit run actionlint --all-files` passes clean on all three workflows (`build-hf-space.yml`, `integration-test.yml`, `space-config.yml`) — no existing findings to fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for GitHub Actions workflow syntax during pre-commit checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->